### PR TITLE
Invalidate cached object based on version/chksum

### DIFF
--- a/ais/dpq.go
+++ b/ais/dpq.go
@@ -27,6 +27,8 @@ type dpq struct {
 	owt                 string // object write transaction { OwtPut, ... }
 	fltPresence         string // QparamFltPresence
 	dontAddRemote       string // QparamDontAddRemote
+	warmVersion         string // QparamWarmVersion
+	warmChkSum          string // QparamWarmChkSum
 }
 
 var (
@@ -105,6 +107,10 @@ func (dpq *dpq) fromRawQ(rawQuery string) (err error) {
 			dpq.fltPresence = value
 		case apc.QparamDontAddRemote:
 			dpq.dontAddRemote = value
+		case apc.QparamWarmVersion:
+			dpq.warmVersion = value
+		case apc.QparamWarmChkSum:
+			dpq.warmChkSum = value
 
 		case s3.QparamMptUploadID, s3.QparamMptUploads, s3.QparamMptPartNo:
 			// TODO: ignore for now

--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -509,7 +509,7 @@ do:
 			}
 			goto fin
 		}
-	} else if goi.lom.Bck().IsRemote() && goi.lom.VersionConf().ValidateWarmGet { // check remote version
+	} else if goi.lom.Bck().IsRemote() && (goi.lom.VersionConf().ValidateWarmGet || goi.ctx.Value(cos.CtxWarmVersion) != nil || goi.ctx.Value(cos.CtxWarmChkSum) != nil) { // check remote version
 		var equal bool
 		goi.lom.Unlock(false)
 		if equal, errCode, err = goi.t.CompareObjects(goi.ctx, goi.lom); err != nil {

--- a/api/apc/query.go
+++ b/api/apc/query.go
@@ -64,6 +64,12 @@ const (
 	// force the operation; allows to overcome certain restrictions (e.g., shutdown primary and the entire cluster)
 	// or errors (e.g., attach invalid mountpath)
 	QparamForce = "frc"
+
+	//Set version in query param to invalidate warm cache if not match working with remote ais cluster
+	QparamWarmVersion = "warm_version"
+
+	//Set checksum in query param to invalidate warm cache if not match working with remote ais cluster
+	QparamWarmChkSum = "warm_chksum"
 )
 
 // QparamFltPresence enum.

--- a/api/client.go
+++ b/api/client.go
@@ -189,6 +189,20 @@ func (reqParams *ReqParams) doReader() (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
+// same as above except that it returns response body (as io.ReadCloser) for subsequent reading and headers
+func (reqParams *ReqParams) doReaderAndHeader() (io.ReadCloser, http.Header, error) {
+	resp, err := reqParams.do()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := reqParams.checkResp(resp); err != nil {
+		resp.Body.Close()
+		return nil, nil, err
+	}
+
+	return resp.Body, resp.Header, nil
+}
+
 // makes HTTP request, retries on connection-refused and reset errors, and returns the response
 func (reqParams *ReqParams) do() (resp *http.Response, err error) {
 	var reqBody io.Reader

--- a/cmn/cos/context.go
+++ b/cmn/cos/context.go
@@ -20,4 +20,6 @@ const (
 	CtxReadWrapper contextID = "readWrapper" // context key for ReadWrapperFunc
 	CtxSetSize     contextID = "setSize"     // context key for SetSizeFunc
 	CtxOriginalURL contextID = "origURL"     // context key for OriginalURL for HTTP cloud
+	CtxWarmVersion contextID = "warmVersion" // context key for WarmVersion
+	CtxWarmChkSum  contextID = "warmChkSum"  // context key for WarmChkSum
 )


### PR DESCRIPTION
Get object from remote cluster if requested objects version/chksum  does not exist in cache and found in remote

Resolve #114 