### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/deploy/prod/k8s/aisadmin_container/Dockerfile
+++ b/deploy/prod/k8s/aisadmin_container/Dockerfile
@@ -14,7 +14,9 @@ RUN git clone https://github.com/NVIDIA/aistore.git && cd aistore && \
 FROM ubuntu:22.04
 
 RUN apt-get update -yq
-RUN apt-get install -y wget sysstat curl git iputils-ping netcat make coreutils net-tools iproute2 tcptrack vim
+RUN apt-get install -y wget sysstat curl git iputils-ping netcat make coreutils net-tools iproute2 tcptrack vim \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/bin
 ENV PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
Hi!
The Dockerfile placed at "deploy/prod/k8s/aisadmin_container/Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance