### PR TITLE
python: add timeout option to client

### DIFF
--- a/python/aistore/sdk/client.py
+++ b/python/aistore/sdk/client.py
@@ -25,8 +25,14 @@ class Client:
         endpoint (str): AIStore endpoint
     """
 
-    def __init__(self, endpoint: str, skip_verify: bool = False, ca_cert: str = None):
-        self._request_client = RequestClient(endpoint, skip_verify, ca_cert)
+    def __init__(
+        self,
+        endpoint: str,
+        skip_verify: bool = False,
+        ca_cert: str = None,
+        timeout: float | tuple[float, float] | None = None,
+    ):
+        self._request_client = RequestClient(endpoint, skip_verify, ca_cert, timeout)
 
     def bucket(
         self, bck_name: str, provider: str = PROVIDER_AIS, namespace: Namespace = None

--- a/python/aistore/sdk/request_client.py
+++ b/python/aistore/sdk/request_client.py
@@ -29,10 +29,17 @@ class RequestClient:
         endpoint (str): AIStore endpoint
     """
 
-    def __init__(self, endpoint: str, skip_verify: bool = False, ca_cert: str = None):
+    def __init__(
+        self,
+        endpoint: str,
+        skip_verify: bool = False,
+        ca_cert: str = None,
+        timeout=None,
+    ):
         self._endpoint = endpoint
         self._base_url = urljoin(endpoint, "v1")
         self._session = requests.sessions.session()
+        self._timeout = timeout
         if "https" in self._endpoint:
             self._set_session_verification(skip_verify, ca_cert)
 
@@ -122,6 +129,7 @@ class RequestClient:
             method,
             url,
             headers=headers,
+            timeout=self._timeout,
             **kwargs,
         )
         if resp.status_code < 200 or resp.status_code >= 300:

--- a/python/tests/unit/sdk/test_client.py
+++ b/python/tests/unit/sdk/test_client.py
@@ -22,14 +22,21 @@ class TestClient(unittest.TestCase):  # pylint: disable=unused-variable
     @patch("aistore.sdk.client.RequestClient")
     def test_init_defaults(self, mock_request_client):
         Client(self.endpoint)
-        mock_request_client.assert_called_with(self.endpoint, False, None)
+        mock_request_client.assert_called_with(self.endpoint, False, None, None)
 
-    @test_cases((True, None), (False, "ca_cert_location"))
+    @test_cases(
+        (True, None, None),
+        (False, "ca_cert_location", None),
+        (False, None, 30.0),
+        (False, None, (10, 30.0)),
+    )
     @patch("aistore.sdk.client.RequestClient")
     def test_init(self, test_case, mock_request_client):
-        skip_verify, ca_cert = test_case
-        Client(self.endpoint, skip_verify=skip_verify, ca_cert=ca_cert)
-        mock_request_client.assert_called_with(self.endpoint, skip_verify, ca_cert)
+        skip_verify, ca_cert, timeout = test_case
+        Client(self.endpoint, skip_verify=skip_verify, ca_cert=ca_cert, timeout=timeout)
+        mock_request_client.assert_called_with(
+            self.endpoint, skip_verify, ca_cert, timeout
+        )
 
     def test_bucket(self):
         bck_name = "bucket_123"

--- a/python/tests/unit/sdk/test_request_client.py
+++ b/python/tests/unit/sdk/test_request_client.py
@@ -108,7 +108,11 @@ class TestRequestClient(unittest.TestCase):  # pylint: disable=unused-variable
                 method, path, headers=extra_headers, keyword=extra_kw_arg
             )
         self.mock_session.request.assert_called_with(
-            method, req_url, headers=self.request_headers, keyword=extra_kw_arg
+            method,
+            req_url,
+            headers=self.request_headers,
+            timeout=None,
+            keyword=extra_kw_arg,
         )
         self.assertEqual(mock_response, res)
 
@@ -124,7 +128,11 @@ class TestRequestClient(unittest.TestCase):  # pylint: disable=unused-variable
                     keyword=extra_kw_arg,
                 )
                 self.mock_session.request.assert_called_with(
-                    method, req_url, headers=self.request_headers, keyword=extra_kw_arg
+                    method,
+                    req_url,
+                    headers=self.request_headers,
+                    timeout=None,
+                    keyword=extra_kw_arg,
                 )
                 self.assertEqual(mock_response, res)
                 mock_handle_err.assert_called_once()


### PR DESCRIPTION
By default internally used requests library doesn't set any timeouts which means that if server doesn't reply to request, call will just hang.

We've run into this issue on our cluster and need an ability to have requests fail after some time of inactivity.

In general, it's a good practice to set default timeouts for any clients that do requests over network. This change introduces an option to set a timeouts as a float, or a (connect timeout, read timeout) tuple that will be applied to all requests done by the client.

The default remains as None to keep backwards compatibility.

Their documentation requests also recommends setting timeouts to most external request:
https://requests.readthedocs.io/en/latest/user/advanced/#timeouts