### PR TITLE
workflows/test-short - Reorder steps to cache dependencies

### DIFF
--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -16,13 +16,13 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Run and test AIStore
         run: |


### PR DESCRIPTION
Reordering the steps here to address a warning on runs:

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/aistore/aistore. Supported file pattern: go.sum

as the code is not yet checked out, reference https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows