### PR TITLE
Extend Dependabot version updates to gomod package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Extending the Dependabot version updates here to the gomod package ecosystem, reference https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-

Example output on my fork -https://github.com/ScottBrenner/aistore/pulls?q=is%3Apr+is%3Aopen+label%3Ago