### PR TITLE
Remove deprecated Req function

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -261,7 +261,7 @@ func GetObjectReader(bp BaseParams, bck cmn.Bck, objName string, args *GetArgs) 
 func (args *PutArgs) getBody() (io.ReadCloser, error) { return args.Reader.Open() }
 
 func (args *PutArgs) put(reqArgs *cmn.HreqArgs) (*http.Request, error) {
-	req, err := reqArgs.ReqDeprecated() // TODO: deprecated; use reqArgs.Req()
+	req, err := reqArgs.Req()
 	if err != nil {
 		return nil, cmn.NewErrCreateHreq(err)
 	}
@@ -518,7 +518,7 @@ func PutApndArch(args *PutApndArchArgs) (err error) {
 func (args *AppendArgs) getBody() (io.ReadCloser, error) { return args.Reader.Open() }
 
 func (args *AppendArgs) _append(reqArgs *cmn.HreqArgs) (*http.Request, error) {
-	req, err := reqArgs.ReqDeprecated() // TODO: deprecated; use reqArgs.Req()
+	req, err := reqArgs.Req()
 	if err != nil {
 		return nil, cmn.NewErrCreateHreq(err)
 	}

--- a/bench/tools/aisloader/client.go
+++ b/bench/tools/aisloader/client.go
@@ -175,7 +175,7 @@ func (t *traceableTransport) set(l *httpLatencies) {
 
 // implements callback of the type `api.NewRequestCB`
 func (putter *tracePutter) do(reqArgs *cmn.HreqArgs) (*http.Request, error) {
-	req, err := reqArgs.ReqDeprecated()
+	req, err := reqArgs.Req()
 	if err != nil {
 		return nil, err
 	}

--- a/cmn/hreq.go
+++ b/cmn/hreq.go
@@ -66,22 +66,6 @@ func (u *HreqArgs) URL() string {
 	return url
 }
 
-// TODO: remaining usage - `api` package (remove when time permits)
-func (u *HreqArgs) ReqDeprecated() (*http.Request, error) {
-	r := u.BodyR
-	if r == nil && u.Body != nil {
-		r = cos.NewByteReader(u.Body)
-	}
-	req, err := http.NewRequest(u.Method, u.URL(), r)
-	if err != nil {
-		return nil, err
-	}
-	if u.Header != nil {
-		copyHeaders(u.Header, &req.Header)
-	}
-	return req, nil
-}
-
 // NOTE: unlike standard http.NewRequest (above)
 // - this method returns context-less request
 // - it also does not assign req.GetBody - it is the caller's responsibility to assign one when and if required

--- a/cmn/tests/bench_hreq_test.go
+++ b/cmn/tests/bench_hreq_test.go
@@ -14,23 +14,7 @@ import (
 
 // go test -bench=. -benchmem -benchtime=5s
 
-func BenchmarkWithoutHpool(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			args := &cmn.HreqArgs{
-				Method: http.MethodGet,
-				Base:   "http://localhost:80",
-				Path:   "/v1/bucket",
-			}
-			_, err := args.ReqDeprecated()
-			if err != nil {
-				panic(err)
-			}
-		}
-	})
-}
-
-func BenchmarkWitHpool(b *testing.B) {
+func BenchmarkWithHpool(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			args := &cmn.HreqArgs{


### PR DESCRIPTION
Found a `TODO` in `cmd/hreq.go`: `TODO: remaining usage - `api` package (remove when time permits)`.

This PR attempts to address that.

Also,
- fixed typo in `BenchmarkWithHpool`
- removed `BenchmarkWithoutHpool` since it _seems_ to be the same logic aside from the call to ReqDeprecated()