### PR TITLE
Add alive_progress to dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,6 +72,7 @@ pytorch = [
     "torch",
     "torchdata",
     "webdataset>=0.2.100",
+    "alive_progress>=3.1.0"
 ]
 botocore = [
     "wrapt",


### PR DESCRIPTION
alive_progress is imported in aistore/pytorch/iter_dataset.py - without this dependency the examples fail to run