### PR TITLE
refactor(benchmark): replace b.N loops with b.Loop()

### DIFF
--- a/ais/tgtobj_internal_test.go
+++ b/ais/tgtobj_internal_test.go
@@ -111,8 +111,7 @@ func BenchmarkObjPut(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				b.StopTimer()
 				r, _ := readers.NewRand(bench.fileSize, cos.ChecksumNone)
 				poi := &putOI{
@@ -131,7 +130,6 @@ func BenchmarkObjPut(b *testing.B) {
 					b.Fatal(err)
 				}
 			}
-			b.StopTimer()
 			lom.RemoveMain()
 		})
 	}
@@ -161,8 +159,7 @@ func BenchmarkObjAppend(b *testing.B) {
 			}
 
 			var hdl aoHdl
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				b.StopTimer()
 				r, _ := readers.NewRand(bench.fileSize, cos.ChecksumNone)
 				aoi := &apndOI{
@@ -185,7 +182,6 @@ func BenchmarkObjAppend(b *testing.B) {
 					b.Fatal(err)
 				}
 			}
-			b.StopTimer()
 			lom.RemoveMain()
 			os.Remove(hdl.workFQN)
 		})
@@ -252,15 +248,13 @@ func BenchmarkObjGetDiscard(b *testing.B) {
 				chunked: bench.chunked,
 			}
 
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_, err := goi.getObject()
 				if err != nil {
 					b.Fatal(err)
 				}
 			}
 
-			b.StopTimer()
 			lom.RemoveMain()
 		})
 	}

--- a/bench/micro/apitests/actionmsg_test.go
+++ b/bench/micro/apitests/actionmsg_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func BenchmarkActionMsgMarshal(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		msg := apc.ActMsg{
 			Name:   "test-name",
 			Action: apc.ActDeleteObjects,

--- a/bench/micro/apitests/listobj_test.go
+++ b/bench/micro/apitests/listobj_test.go
@@ -73,8 +73,8 @@ func BenchmarkListObject(b *testing.B) {
 				baseParams = tools.BaseAPIParams(u)
 			)
 			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
+			// b.Loop will handle b.ResetTimer and b.StopTimer
+			for b.Loop() {
 				msg := &apc.LsoMsg{PageSize: int64(test.pageSize)}
 				objs, err := api.ListObjects(baseParams, bck, msg, api.ListArgs{})
 				tassert.CheckFatal(b, err)
@@ -83,7 +83,6 @@ func BenchmarkListObject(b *testing.B) {
 					"expected %d objects got %d", test.objectCnt, len(objs.Entries),
 				)
 			}
-			b.StopTimer() // Otherwise we will include `DestroyBucket`.
 		})
 	}
 }

--- a/bench/micro/hrw/hrw_bench_internal_test.go
+++ b/bench/micro/hrw/hrw_bench_internal_test.go
@@ -42,7 +42,7 @@ func BenchmarkHRW(b *testing.B) {
 			for _, hashFunc := range hashFuncs {
 				b.Run(fmt.Sprintf("%s/%d/%d", hashFunc.name, numNodes, nameLen), func(b *testing.B) {
 					var nodeID int
-					for range b.N {
+					for b.Loop() {
 						// Record the result to prevent the compiler
 						// eliminating the function call.
 						nodeID = hashFunc.hashF(fileName, nodes)

--- a/bench/micro/lstat/basic_test.go
+++ b/bench/micro/lstat/basic_test.go
@@ -18,35 +18,35 @@ const (
 )
 
 func BenchmarkAccess(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		access(b, one)
 		access(b, two)
 	}
 }
 
 func BenchmarkStat(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		stat(b, one)
 		stat(b, two)
 	}
 }
 
 func BenchmarkLstat(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		lstat(b, one)
 		lstat(b, two)
 	}
 }
 
 func BenchmarkOpen(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		open(b, one)
 		open(b, two)
 	}
 }
 
 func BenchmarkSyscallStat(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		syscallStat(b, one)
 		syscallStat(b, two)
 	}

--- a/bench/micro/nstlvl/nstlvl_test.go
+++ b/bench/micro/nstlvl/nstlvl_test.go
@@ -93,7 +93,7 @@ func BenchmarkNestedLevel(b *testing.B) {
 }
 
 func benchNestedLevel(b *testing.B) {
-	for i, j, k := 0, 0, 0; i < b.N; i, j = i+1, j+benchCtx.skipMod {
+	for i, j, k := 0, 0, 0; b.Loop(); i, j = i+1, j+benchCtx.skipMod {
 		if j >= benchCtx.fileCount {
 			k++
 			if k >= benchCtx.skipMod {

--- a/bench/tools/aisloader/test/objnamegetter_test.go
+++ b/bench/tools/aisloader/test/objnamegetter_test.go
@@ -42,8 +42,7 @@ func TestMain(m *testing.M) {
 func BenchmarkRandomUniqueNameGetter(b *testing.B) {
 	ng := &namegetter.RandomUniqueNameGetter{}
 	ng.Init(objNames, cos.NowRand())
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		ng.ObjName()
 	}
 }
@@ -51,8 +50,7 @@ func BenchmarkRandomUniqueNameGetter(b *testing.B) {
 func BenchmarkRandomUniqueIterNameGetter(b *testing.B) {
 	ng := &namegetter.RandomUniqueIterNameGetter{}
 	ng.Init(objNames, cos.NowRand())
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		ng.ObjName()
 	}
 }
@@ -60,8 +58,7 @@ func BenchmarkRandomUniqueIterNameGetter(b *testing.B) {
 func BenchmarkPermutationUniqueNameGetter(b *testing.B) {
 	ng := &namegetter.PermutationUniqueNameGetter{}
 	ng.Init(objNames, cos.NowRand())
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		ng.ObjName()
 	}
 }
@@ -69,8 +66,7 @@ func BenchmarkPermutationUniqueNameGetter(b *testing.B) {
 func BenchmarkPermutationImprovedUniqueNameGetter(b *testing.B) {
 	ng := &namegetter.PermutationUniqueImprovedNameGetter{}
 	ng.Init(objNames, cos.NowRand())
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		ng.ObjName()
 	}
 }

--- a/cmn/jsp/io_test.go
+++ b/cmn/jsp/io_test.go
@@ -166,9 +166,8 @@ func BenchmarkEncode(b *testing.B) {
 				body.Free()
 			}()
 			b.ReportAllocs()
-			b.ResetTimer()
 
-			for range b.N {
+			for b.Loop() {
 				err := jsp.Encode(body, bench.v, bench.opts)
 				tassert.CheckFatal(b, err)
 				body.Reset()
@@ -202,9 +201,8 @@ func BenchmarkDecode(b *testing.B) {
 			sgl.Free()
 
 			b.ReportAllocs()
-			b.ResetTimer()
 
-			for range b.N {
+			for b.Loop() {
 				var (
 					v testStruct
 					r = io.NopCloser(bytes.NewReader(network))

--- a/fs/fqn_test.go
+++ b/fs/fqn_test.go
@@ -407,9 +407,8 @@ func BenchmarkParseFQN(b *testing.B) {
 
 	mpaths := fs.GetAvail()
 	fqn := mpaths[mpath].MakePathFQN(&bck, fs.ObjectType, "super/long/name")
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		var parsed fs.ParsedFQN
 		parsed.Init(fqn)
 	}

--- a/fs/mountfs_test.go
+++ b/fs/mountfs_test.go
@@ -328,8 +328,7 @@ func BenchmarkMakePathFQN(b *testing.B) {
 	)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		s := mi.MakePathFQN(&bck, fs.ObjectType, objName)
 		cos.Assert(s != "")
 	}

--- a/fs/utils_test.go
+++ b/fs/utils_test.go
@@ -74,8 +74,7 @@ func BenchmarkIsDirEmpty(b *testing.B) {
 			topDirName, _ := tools.PrepareDirTree(b, bench)
 			defer os.RemoveAll(topDirName)
 
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_, empty, err := fs.IsDirEmpty(topDirName)
 				tassert.CheckFatal(b, err)
 				tassert.Errorf(

--- a/memsys/d256_test.go
+++ b/memsys/d256_test.go
@@ -70,9 +70,8 @@ func benchAlloc(b *testing.B, objsiz, sbufSize int64) {
 
 	// reset initial conditions & start b-timer
 	rdebug.FreeOSMemory()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		sgl := mem.NewSGL(objsiz, sbufSize)
 		_ = sgl
 	}
@@ -120,9 +119,8 @@ func benchWrite(b *testing.B, objsiz, sbufSize int64) {
 	// reset initial conditions & start b-timer
 	rdebug.FreeOSMemory()
 	buf := make([]byte, cos.KiB*128)
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		sgl := mem.NewSGL(objsiz, sbufSize)
 		for siz := 0; siz < int(objsiz); siz += len(buf) {
 			sgl.Write(buf)
@@ -184,9 +182,7 @@ func benchWRF(b *testing.B, objsiz, sbufSize int64) {
 		}
 	}(cha)
 
-	b.ResetTimer() // <==== start
-
-	for range b.N {
+	for b.Loop() {
 		sgl := mem.NewSGL(objsiz, sbufSize)
 		for siz := 0; siz < int(objsiz); siz += l {
 			n, _ := sgl.Write(buf)
@@ -201,7 +197,6 @@ func benchWRF(b *testing.B, objsiz, sbufSize int64) {
 		default:
 		}
 	}
-	b.StopTimer() // wo/ defers
 }
 
 // file read to sgl
@@ -252,13 +247,11 @@ func benchFile(b *testing.B, sbufSize int64) {
 		b.Fatal(len(buf), sbufSize)
 	}
 
-	b.ResetTimer() // start timing it
-	for range b.N {
+	for b.Loop() {
 		file.Seek(0, io.SeekStart)
 		n, _ := io.CopyBuffer(io.Discard, file, buf)
 		if n != largefil {
 			b.Fatal(n, largefil)
 		}
 	}
-	b.StopTimer() // wo/ defers
 }

--- a/stats/statsd/client_test.go
+++ b/stats/statsd/client_test.go
@@ -145,7 +145,7 @@ func BenchmarkSend(b *testing.B) {
 	}
 	defer c.Close()
 
-	for range b.N {
+	for b.Loop() {
 		c.Send("timer", 1,
 			statsd.Metric{
 				Type:  statsd.Timer,

--- a/tools/client_test.go
+++ b/tools/client_test.go
@@ -98,7 +98,7 @@ func putSG(sgl *memsys.SGL, size int64, cksumType string) error {
 }
 
 func BenchmarkPutFileWithHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		err := putFile(1024*1024, cos.ChecksumCesXxh)
 		if err != nil {
 			b.Fatal(err)
@@ -107,7 +107,7 @@ func BenchmarkPutFileWithHash1M(b *testing.B) {
 }
 
 func BenchmarkPutRandWithHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		err := putRand(1024*1024, cos.ChecksumCesXxh)
 		if err != nil {
 			b.Fatal(err)
@@ -120,7 +120,7 @@ func BenchmarkPutSGWithHash1M(b *testing.B) {
 	sgl := mmsa.NewSGL(cos.MiB)
 	defer sgl.Free()
 
-	for range b.N {
+	for b.Loop() {
 		err := putSG(sgl, 1024*1024, cos.ChecksumCesXxh)
 		if err != nil {
 			b.Fatal(err)
@@ -129,7 +129,7 @@ func BenchmarkPutSGWithHash1M(b *testing.B) {
 }
 
 func BenchmarkPutFileNoHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		err := putFile(1024*1024, cos.ChecksumNone)
 		if err != nil {
 			b.Fatal(err)
@@ -138,7 +138,7 @@ func BenchmarkPutFileNoHash1M(b *testing.B) {
 }
 
 func BenchmarkPutRandNoHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		err := putRand(1024*1024, cos.ChecksumNone)
 		if err != nil {
 			b.Fatal(err)
@@ -151,7 +151,7 @@ func BenchmarkPutSGNoHash1M(b *testing.B) {
 	sgl := mmsa.NewSGL(cos.MiB)
 	defer sgl.Free()
 
-	for range b.N {
+	for b.Loop() {
 		err := putSG(sgl, 1024*1024, cos.ChecksumNone)
 		if err != nil {
 			b.Fatal(err)

--- a/tools/readers/readers_test.go
+++ b/tools/readers/readers_test.go
@@ -297,7 +297,7 @@ func BenchmarkFileReaderCreateWithHash1M(b *testing.B) {
 	filepath := "/tmp"
 	fn := "reader-test"
 
-	for range b.N {
+	for b.Loop() {
 		r, err := readers.NewRandFile(filepath, fn, cos.MiB, cos.ChecksumCesXxh)
 		if err != nil {
 			os.Remove(path.Join(filepath, fn))
@@ -312,7 +312,7 @@ func BenchmarkFileReaderCreateWithHash1M(b *testing.B) {
 }
 
 func BenchmarkRandReaderCreateWithHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		r, err := readers.NewRand(cos.MiB, cos.ChecksumCesXxh)
 		r.Close()
 		if err != nil {
@@ -329,7 +329,7 @@ func BenchmarkSGReaderCreateWithHash1M(b *testing.B) {
 		mmsa.Terminate(false)
 	}()
 
-	for range b.N {
+	for b.Loop() {
 		sgl.Reset()
 		r, err := readers.NewSG(sgl, cos.MiB, cos.ChecksumCesXxh)
 		r.Close()
@@ -343,7 +343,7 @@ func BenchmarkFileReaderCreateNoHash1M(b *testing.B) {
 	filepath := "/tmp"
 	fn := "reader-test"
 
-	for range b.N {
+	for b.Loop() {
 		r, err := readers.NewRandFile(filepath, fn, cos.MiB, cos.ChecksumNone)
 		if err != nil {
 			os.Remove(path.Join(filepath, fn))
@@ -358,7 +358,7 @@ func BenchmarkFileReaderCreateNoHash1M(b *testing.B) {
 }
 
 func BenchmarkRandReaderCreateNoHash1M(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		r, err := readers.NewRand(cos.MiB, cos.ChecksumNone)
 		r.Close()
 		if err != nil {
@@ -375,7 +375,7 @@ func BenchmarkSGReaderCreateNoHash1M(b *testing.B) {
 		mmsa.Terminate(false)
 	}()
 
-	for range b.N {
+	for b.Loop() {
 		sgl.Reset()
 		r, err := readers.NewSG(sgl, cos.MiB, cos.ChecksumNone)
 		r.Close()


### PR DESCRIPTION
* Eliminates the need for explicit calls to b.ResetTimer and b.StopTimer for setup and cleanup.
* Prevents dead code elimination within the loop.

For reference: https://go.dev/blog/testing-b-loop