### PR TITLE
Fix status code for range reads

### DIFF
--- a/ais/test/object_test.go
+++ b/ais/test/object_test.go
@@ -1691,6 +1691,10 @@ func verifyValidRangesQuery(t *testing.T, proxyURL string, bck cmn.Bck, objName,
 		cos.HdrAcceptRanges, acceptRanges)
 	contentRange := respHeader.Get(cos.HdrContentRange)
 	tassert.Errorf(t, contentRange != "", "%q header should be set", cos.HdrContentRange)
+
+	// verify 206 Partial Content status code
+	tassert.Errorf(t, oah.StatusCode() == http.StatusPartialContent,
+		"expected 206 Partial Content, got %d", oah.StatusCode())
 }
 
 func verifyInvalidRangesQuery(t *testing.T, proxyURL string, bck cmn.Bck, objName, rangeQuery string) {

--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -1137,6 +1137,8 @@ func (goi *getOI) _txrng(fqn string, lmfh cos.LomReader, whdr http.Header, hrng 
 
 	goi.setwhdr(whdr, cksum, size)
 
+	goi.w.WriteHeader(http.StatusPartialContent)
+
 	// transmit
 	buf, slab := goi.t.gmm.AllocSize(_txsize(size))
 	err := goi.transmit(r, buf, fqn, size)

--- a/api/object.go
+++ b/api/object.go
@@ -70,6 +70,7 @@ type (
 	ObjAttrs struct {
 		wrespHeader http.Header
 		n           int64
+		statusCode  int
 	}
 )
 
@@ -185,6 +186,11 @@ func (oah *ObjAttrs) RespHeader() http.Header {
 	return oah.wrespHeader
 }
 
+// StatusCode returns the HTTP status code of the response (e.g., 200, 206)
+func (oah *ObjAttrs) StatusCode() int {
+	return oah.statusCode
+}
+
 func GetObject(bp BaseParams, bck cmn.Bck, objName string, args *GetArgs) (oah ObjAttrs, err error) {
 	var (
 		wresp     *wrappedResp
@@ -214,7 +220,7 @@ func GetObject(bp BaseParams, bck cmn.Bck, objName string, args *GetArgs) (oah O
 	FreeRp(reqParams)
 	qfree(qall)
 	if err == nil {
-		oah.wrespHeader, oah.n = wresp.Header, wresp.n
+		oah.wrespHeader, oah.n, oah.statusCode = wresp.Header, wresp.n, wresp.StatusCode
 	}
 	return oah, err
 }
@@ -255,7 +261,7 @@ func GetObjectWithValidation(bp BaseParams, bck cmn.Bck, objName string, args *G
 	resp.Body.Close()
 	FreeRp(reqParams)
 	if err == nil {
-		oah.wrespHeader, oah.n = wresp.Header, wresp.n
+		oah.wrespHeader, oah.n, oah.statusCode = wresp.Header, wresp.n, wresp.StatusCode
 	} else if err.Error() == errNilCksum {
 		err = fmt.Errorf("%s is not checksummed, cannot validate", bck.Cname(objName))
 	}


### PR DESCRIPTION
### Issue
According to [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-range), "If all of the preconditions are true, the server supports the Range header field for the target resource, the received Range field-value contains a valid ranges-specifier with a range-unit supported for that target resource, and that ranges-specifier is satisfiable with respect to the selected representation, the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations that correspond to the satisfiable range-spec(s) requested."

Issue repro:
`curl -L -H "Range: bytes=0-1023" -i <URL> --output data.txt`
Returns a proper range read response but without the 206 status code
```
HTTP/1.1 200 OK^M
Accept-Ranges: bytes^M
Content-Length: 1024^M
Content-Range: bytes 0-1023/33241197^M
```

This incorrect status code makes it not possible to open a [lance](https://lance.org/) dataset

### Fix
Returns a 206 status code
