### PR TITLE
python/sdk: export Batch from top-level __init__.py

### DIFF
--- a/python/aistore/sdk/__init__.py
+++ b/python/aistore/sdk/__init__.py
@@ -16,6 +16,7 @@ from aistore.sdk.bucket import Bucket
 from aistore.sdk.obj.object import Object
 from aistore.sdk.job import Job
 from aistore.sdk.etl.etl import Etl
+from aistore.sdk.batch.batch import Batch
 
 # Config objects, types and dataclasses
 from aistore.sdk.archive_config import ArchiveConfig


### PR DESCRIPTION
The `Batch` class is missing from `sdk/__init__.py` — an oversight from the
October 2025 refactoring (a19b22c62) that replaced `BatchRequest`/
`BatchResponseItem` with the new `Batch` class. The predecessors were
exported; the replacement was not.

Every other factory-created core class (`Bucket`, `Object`, `Job`, `Etl`,
`Cluster`) is exported from the top-level package. `Batch` is the only
exception, despite being obtained the same way via `Client.batch()`.

This one-line fix makes `from aistore.sdk import Batch` work, enabling
users to use `Batch` in type annotations without reaching into the internal
submodule path.