### PR TITLE
api: drain response body before close in CheckObjectLock

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -823,6 +823,7 @@ func CheckObjectLock(bp BaseParams, bck cmn.Bck, objName string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	cos.DrainReader(resp.Body)
 	resp.Body.Close()
 
 	switch status := resp.StatusCode; status {


### PR DESCRIPTION
## Problem

`CheckObjectLock` in `api/object.go` closes `resp.Body` without draining it first. When an HTTP response body has unread data remaining, closing without draining prevents the underlying TCP connection from being reused by the connection pool (`net/http` transport), which can lead to unnecessary connection churn under load.

## Motivation

All other callers in `api/client.go` and `api/object.go` consistently call `cos.DrainReader(resp.Body)` before `resp.Body.Close()`. This function was the only exception to that pattern.

## Changes

Added `cos.DrainReader(resp.Body)` before the existing `resp.Body.Close()` call in `CheckObjectLock`, matching the established cleanup pattern used throughout the `api` package.

## Testing

- Verified the change compiles and follows the existing drain-then-close pattern used at `api/object.go:257`, `api/object.go:904`, `api/client.go:144`, `api/client.go:156`, `api/client.go:170`, `api/client.go:262`, and `api/stats.go:110`.
- No behavioral change for callers — this is a resource cleanup fix only.