### PR TITLE
ais: exclude 404 from ais_target_err_get_count

### DIFF
--- a/ais/target.go
+++ b/ais/target.go
@@ -909,13 +909,17 @@ func (t *target) getObject(w http.ResponseWriter, r *http.Request, dpq *dpq, bck
 	if ecode, err := goi.getObject(); err != nil {
 		// stats
 		vlabs := map[string]string{stats.VlabBucket: bck.Cname("")}
-		if goi.isIOErr {
+		switch {
+		case goi.isIOErr:
 			t.statsT.IncWith(stats.ErrGetCount, vlabs)
 			t.statsT.IncWith(stats.IOErrGetCount, vlabs)
 			if cmn.Rom.V(4, cos.ModAIS) {
 				nlog.Warningln("io-error [", err, "]", goi.lom.String())
 			}
-		} else {
+		case ecode != http.StatusNotFound:
+			// 404 is a caller-visible "no such object", not a target-side error.
+			// Counting it here made ais_target_err_get_count spike whenever a
+			// client probed non-existent keys - see #286.
 			t.statsT.IncWith(stats.ErrGetCount, vlabs)
 		}
 


### PR DESCRIPTION
## Summary

`target.httpObjGet` increments `ErrGetCount` on every non-nil error from `goi.getObject()`, which conflates target-side failures with caller-visible `http.StatusNotFound` responses. A client probing for a non-existent key bumps `ais_target_err_get_count` and, in operator-reported scenarios, trips Prometheus alerts configured for server errors.

Fixes #286.

## Change

Rewrite the stats branch in `ais/target.go` as a `switch`:

- `goi.isIOErr` still counts both `ErrGetCount` and `IOErrGetCount` — a real target-side I/O failure is always an error, even if the upstream ecode is 404.
- The remaining branch only counts `ErrGetCount` when `ecode != http.StatusNotFound`. 404 is a caller-visible "no such object" response, not a target failure.

The same file already treats 404 as a separate case in `HeadCold`'s error switch (`ais/target.go:1418`), so this is consistent with existing practice in the codebase.

## Testing

- `make lint`, `make fmt-check` pass.
- `BUCKET=tmp make test-short` passes.
- Manually exercised `GET` on a non-existent key: `ais_target_err_get_count` no longer increments, `ais_target_err_io_get_count` unchanged for real I/O errors.
