### PR TITLE
python/etl: tighten HTTP streaming lifecycle

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -19,6 +19,12 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
   shared `requests.Session`, wrapped in `asyncio.to_thread` to keep the event
   loop responsive. Previously the full upstream object was buffered into memory
   before being handed to `transform_stream`.
+- ETL `HTTPMultiThreadedServer`: release upstream keep-alive connections
+  through response-level close on early-close, error, and client-disconnect
+  paths (previously `resp.raw.close()` skipped `release_conn()` and leaked
+  sockets from the urllib3 pool). Forward upstream HTTP error statuses as-is
+  instead of collapsing them, and map `requests.RequestException` to HTTP 502
+  (was 500) for the no-FQN `hpull` GET path.
 - **ETL direct-put retry**: added exponential-backoff retry for transient connection
   errors in Flask and HTTP multi-threaded ETL servers for parity with FastAPI.
   `ConnectionRefused` is now treated as a permanent error that returns HTTP 502

--- a/python/aistore/sdk/etl/webserver/fastapi_server.py
+++ b/python/aistore/sdk/etl/webserver/fastapi_server.py
@@ -31,6 +31,7 @@ from aistore.sdk.session_manager import resolve_ssl_config
 from aistore.sdk.etl.webserver.utils import (
     compose_etl_direct_put_url,
     parse_etl_pipeline,
+    _ResponseRawReader,
 )
 from aistore.sdk.errors import InvalidPipelineError, ETLDirectPutTransientError
 from aistore.sdk.const import (
@@ -50,32 +51,6 @@ from aistore.sdk.const import (
     STATUS_INTERNAL_SERVER_ERROR,
     HEADER_AUTHORIZATION,
 )
-
-
-class _ResponseRawReader:
-    """Wrap a requests.Response so close() releases the connection to the pool.
-
-    resp.raw.close() closes the socket but skips resp.close()'s release_conn()
-    call, which returns the socket to the keep-alive pool. Under early-close
-    (mid-stream errors, client disconnects), that leaks connections.
-    All reads are delegated to resp.raw; everything else falls through to resp.raw.
-    """
-
-    def __init__(self, response: requests.Response):
-        self._response = response
-        self._raw = response.raw
-
-    def read(self, *args, **kwargs):
-        """Read bytes from the underlying raw response stream."""
-        return self._raw.read(*args, **kwargs)
-
-    def close(self):
-        """Close the response so requests releases the connection to the pool."""
-        self._response.close()
-
-    def __getattr__(self, name):
-        return getattr(self._raw, name)
-
 
 HTTP_LIMITS = httpx.Limits(
     max_connections=int(os.getenv("MAX_CONN", "256")),

--- a/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
+++ b/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
@@ -24,6 +24,7 @@ from aistore.sdk.etl.webserver.base_etl_server import (
 from aistore.sdk.etl.webserver.utils import (
     compose_etl_direct_put_url,
     parse_etl_pipeline,
+    _ResponseRawReader,
 )
 from aistore.sdk.errors import InvalidPipelineError, ETLDirectPutTransientError
 from aistore.sdk.const import (
@@ -154,10 +155,15 @@ class HTTPMultiThreadedServer(ETLServer):
                     "Forwarding GET (stream) to AIS target: %s", target_url
                 )
                 resp = etl_server.session.get(target_url, stream=True, timeout=None)
-                if resp.status_code != STATUS_OK:
+                try:
+                    resp.raise_for_status()
+                except requests.HTTPError:
                     resp.close()
-                    return None
-                return resp.raw
+                    raise
+                return _ResponseRawReader(resp)
+            # TODO: non-FQN PUT still buffers the full request body into BytesIO so
+            # retries can replay it; true streaming for this path still needs to be
+            # implemented.
             content_length = int(self.headers.get(HEADER_CONTENT_LENGTH, 0))
             return BytesIO(self.rfile.read(content_length))
 
@@ -209,12 +215,6 @@ class HTTPMultiThreadedServer(ETLServer):
             """
             etl = self.server.etl_server
             reader = self._get_stream_reader(fqn, raw_path, is_get)
-            if reader is None:
-                return (
-                    STATUS_BAD_GATEWAY,
-                    b"Failed to retrieve data from target",
-                    0,
-                )
             try:
                 for attempt in range(etl.direct_put_retries + 1):
                     try:
@@ -241,8 +241,6 @@ class HTTPMultiThreadedServer(ETLServer):
                         else:
                             etl.close_reader(reader)
                             reader = self._get_stream_reader(fqn, raw_path, is_get)
-                            if reader is None:
-                                raise
                         time.sleep(delay)
             finally:
                 etl.close_reader(reader)
@@ -353,11 +351,6 @@ class HTTPMultiThreadedServer(ETLServer):
 
             # No pipeline: original reader-based streaming path
             reader = self._get_stream_reader(fqn, raw_path, is_get=is_get)
-            if reader is None:
-                self.send_error(
-                    STATUS_BAD_GATEWAY, "Failed to retrieve data from target"
-                )
-                return
             try:
                 output_iter = self.server.etl_server.transform_stream(
                     reader, raw_path, etl_args
@@ -366,7 +359,7 @@ class HTTPMultiThreadedServer(ETLServer):
             finally:
                 self.server.etl_server.close_reader(reader)
 
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-many-statements
         def do_GET(self):
             """
             Handle GET requests by forwarding them to the AIS target or reading from FQN,
@@ -456,9 +449,17 @@ class HTTPMultiThreadedServer(ETLServer):
                 self.send_error(
                     STATUS_BAD_GATEWAY, f"Direct put failed after retries: {e}"
                 )
+            except requests.HTTPError as e:
+                status = (
+                    e.response.status_code
+                    if e.response is not None
+                    else STATUS_BAD_GATEWAY
+                )
+                logger.debug("Upstream GET returned %s", status)
+                self.send_error(status, "Target request failed")
             except requests.RequestException as e:
                 logger.error("Request to AIS target failed: %s", str(e))
-                self.send_error(500, f"Error contacting AIS target: {e}")
+                self.send_error(STATUS_BAD_GATEWAY, f"Error contacting AIS target: {e}")
 
             except Exception as e:
                 logger.exception("Unexpected error processing GET request")

--- a/python/aistore/sdk/etl/webserver/utils.py
+++ b/python/aistore/sdk/etl/webserver/utils.py
@@ -7,9 +7,35 @@ from typing import Type, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import cloudpickle
+import requests
 from aistore.sdk.etl.webserver.base_etl_server import ETLServer
 from aistore.sdk.const import UTF_ENCODING
 from aistore.sdk.errors import InvalidPipelineError
+
+
+class _ResponseRawReader:
+    """Wrap a requests.Response so close() releases the connection to the pool.
+
+    resp.raw.close() closes the socket but skips resp.close()'s release_conn()
+    call, which returns the socket to the keep-alive pool. Under early-close
+    (mid-stream errors, client disconnects), that leaks connections.
+    All reads are delegated to resp.raw; everything else falls through to resp.raw.
+    """
+
+    def __init__(self, response: requests.Response):
+        self._response = response
+        self._raw = response.raw
+
+    def read(self, *args, **kwargs):
+        """Read bytes from the underlying raw response stream."""
+        return self._raw.read(*args, **kwargs)
+
+    def close(self):
+        """Close the response so requests releases the connection to the pool."""
+        self._response.close()
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
 
 
 def serialize_class(cls: Type[ETLServer], encoding: str = UTF_ENCODING) -> str:

--- a/python/tests/unit/sdk/test_etl_webserver.py
+++ b/python/tests/unit/sdk/test_etl_webserver.py
@@ -1311,6 +1311,84 @@ class TestStreamingHTTPServer(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# HTTP streaming lifecycle: connection release, status forwarding, 502 mapping
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPStreamingLifecycle(unittest.TestCase):
+    """Tests for the response-lifecycle correctness fixes in HTTPMultiThreadedServer."""
+
+    def setUp(self):
+        os.environ["AIS_TARGET_URL"] = "http://localhost:8080"
+
+    def _make_streaming_handler(self):
+        handler = DummyRequestHandler()
+        handler.server.etl_server.use_streaming = True
+        handler.server.etl_server.transform_stream.return_value = iter([b"TRANSFORMED"])
+        handler.server.etl_server.close_reader = MagicMock()
+        return handler
+
+    def _make_ok_resp(self, body=b"data"):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.raw = io.BytesIO(body)
+        return mock_resp
+
+    def test_reader_close_releases_pool_connection(self):
+        """close() on the reader from _get_stream_reader calls resp.close(), not just raw.close()."""
+        handler = DummyRequestHandler()
+        mock_resp = self._make_ok_resp()
+        handler.server.etl_server.session.get.return_value = mock_resp
+
+        reader = handler._get_stream_reader(  # pylint: disable=protected-access
+            fqn="", raw_path="/some/key", is_get=True
+        )
+        reader.close()
+        mock_resp.close.assert_called_once()
+
+    def test_upstream_non200_status_forwarded(self):
+        """Non-200 upstream responses propagate the exact status code (not collapsed to 502)."""
+        handler = self._make_streaming_handler()
+        handler.path = "/test/object"
+        mock_resp = MagicMock()
+        mock_http_error = requests.HTTPError(response=MagicMock(status_code=404))
+        mock_resp.raise_for_status.side_effect = mock_http_error
+        handler.server.etl_server.session.get.return_value = mock_resp
+
+        handler.do_GET()
+
+        handler.send_error.assert_called_once()
+        self.assertEqual(handler.send_error.call_args[0][0], 404)
+
+    def test_network_error_returns_502(self):
+        """requests.RequestException (network failure) maps to 502, not 500."""
+        handler = self._make_streaming_handler()
+        handler.path = "/test/object"
+        handler.server.etl_server.session.get.side_effect = requests.ConnectionError(
+            "connection refused"
+        )
+
+        handler.do_GET()
+
+        handler.send_error.assert_called_once()
+        self.assertEqual(handler.send_error.call_args[0][0], 502)
+
+    def test_client_disconnect_mid_stream_releases_connection(self):
+        """BrokenPipeError mid-stream still calls close_reader via the finally block."""
+        handler = self._make_streaming_handler()
+        handler.path = "/test/object"
+        mock_resp = self._make_ok_resp()
+        handler.server.etl_server.session.get.return_value = mock_resp
+        handler.server.etl_server.transform_stream.return_value = iter([b"chunk"])
+        handler.wfile = MagicMock()
+        handler.wfile.write.side_effect = BrokenPipeError("client disconnected")
+
+        handler.do_GET()
+
+        handler.server.etl_server.close_reader.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # _direct_put_stream_with_retry unit tests
 # ---------------------------------------------------------------------------
 
@@ -2021,30 +2099,46 @@ class TestHTTPStreamingDirectPutRetry(unittest.TestCase):
                     with self.assertRaises(ETLDirectPutTransientError):
                         self._call()
 
-    def test_reader_none_returns_error_tuple(self):
-        """When _get_stream_reader returns None, a 502 error tuple is returned (no send_error)."""
-        with patch.object(self.handler, "_get_stream_reader", return_value=None):
-            result = self._call()
-        self.assertEqual(result[0], 502)
-        # send_error must NOT be called — that would write a second response
-        self.handler.send_error.assert_not_called()
+    def test_upstream_error_propagates_from_direct_put(self):
+        """When _get_stream_reader raises HTTPError (upstream non-200), it propagates."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        err = requests.HTTPError(response=mock_response)
+        with patch.object(self.handler, "_get_stream_reader", side_effect=err):
+            with self.assertRaises(requests.HTTPError):
+                self._call()
 
-    def test_reader_none_on_retry_raises(self):
-        """When reader reopening returns None on retry, the transient error is re-raised."""
+    def test_upstream_error_on_retry_reopen_propagates(self):
+        """When reader reopening raises HTTPError on retry (GET path), the error propagates."""
         self.handler.server.etl_server.direct_put_retries = 2
-        err = ETLDirectPutTransientError(
+        transient_err = ETLDirectPutTransientError(
             self._DIRECT_PUT_URL, requests.ConnectionError()
         )
-        # First reader open succeeds; reopening on retry returns None
-        readers = [self._make_reader(), None]
-        reader_iter = iter(readers)
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        upstream_err = requests.HTTPError(response=mock_response)
+        # Use a non-BytesIO reader so the retry loop calls _get_stream_reader again
+        # (BytesIO triggers seek(0) instead of reopening).
+        first_reader = MagicMock()
+        first_reader.close = MagicMock()
+        side_effects = [first_reader, upstream_err]
+        side_effect_iter = iter(side_effects)
+
+        def reader_side_effect(*_):
+            val = next(side_effect_iter)
+            if isinstance(val, Exception):
+                raise val
+            return val
+
         with patch.object(
-            self.handler, "_get_stream_reader", side_effect=lambda *_: next(reader_iter)
+            self.handler, "_get_stream_reader", side_effect=reader_side_effect
         ):
-            with patch.object(self.handler, "_direct_put_stream", side_effect=err):
+            with patch.object(
+                self.handler, "_direct_put_stream", side_effect=transient_err
+            ):
                 with patch("time.sleep"):
-                    with self.assertRaises(ETLDirectPutTransientError):
-                        self._call()
+                    with self.assertRaises(requests.HTTPError):
+                        self._call(is_get=True)
 
     def test_reader_reopened_on_each_retry(self):
         """For BytesIO readers (PUT-no-FQN), seek(0) is used on retry instead of


### PR DESCRIPTION
Follow up to PR #285 for the sync `HTTPMultiThreadedServer` streaming GET path.

Before this change, `HTTPMultiThreadedServer` already used `requests.Session.get(..., stream=True)` for no-FQN streaming GETs, but it handed `resp.raw` directly to `transform_stream()`. On early close, transform errors, or client disconnects, closing only `resp.raw` could skip response-level `resp.close()` / urllib3 `release_conn()`. The old path also collapsed upstream streaming GET failures through a `None` reader path, and network-level `requests.RequestException` failures returned 500.

This updates no-FQN `hpull` GET handling to:

- release upstream keep-alive connections via response-level `close()`, so urllib3 `release_conn()` runs instead of closing only `resp.raw`
- preserve upstream HTTP error statuses instead of collapsing them to 502
- map network-level `requests.RequestException` failures to 502
- share the response-reader wrapper with the FastAPI implementation from #285

The non-FQN PUT path is intentionally left buffered for retry replay; a TODO notes that true PUT streaming still needs a separate design.