### PR TITLE
authn: Redis backend for multi-replica/HA deployments

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,28 @@
+AIStore includes the following third-party software with their respective licenses:
+
+--------------------------------------------------------------------------------
+github.com/redis/go-redis/v9
+Copyright (c) 2013 The github.com/redis/go-redis Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------

--- a/api/authn/config.go
+++ b/api/authn/config.go
@@ -38,6 +38,7 @@ const (
 	defaultLogFlushInterval = cos.Duration(30 * time.Second)
 	defaultTimeout          = cos.Duration(30 * time.Second)
 	defaultPort             = 52001
+	defaultKVServiceAddr    = "localhost:6379"
 )
 
 type (
@@ -76,17 +77,17 @@ type (
 		DBConf     DatabaseConf `json:"db"`
 	}
 	DatabaseConf struct {
-		DBType   string    `json:"type"`
-		Filepath string    `json:"filepath,omitempty"`
-		Redis    RedisConf `json:"redis,omitempty"`
+		DBType   string        `json:"type"`
+		Filepath string        `json:"filepath,omitempty"`
+		Service  KVServiceConf `json:"service,omitempty"`
 	}
 
-	// RedisConf holds connection parameters for the Redis backend.
+	// KVServiceConf holds connection parameters for an external key-value service backend.
 	// All fields are overridable via environment variables.
-	RedisConf struct {
-		Addr       string `json:"addr"`                 // host:port, default "localhost:6379"
-		Password   string `json:"password,omitempty"`   //nolint:gosec // not a hardcoded cred
-		DB         int    `json:"db,omitempty"`         // Redis DB index (0–15), default 0
+	KVServiceConf struct {
+		Addr       string `json:"addr"`                  // host:port
+		Password   string `json:"password,omitempty"`    //nolint:gosec // not a hardcoded cred
+		DBIndex    int    `json:"db_index,omitempty"`    // database index (e.g. Redis DB 0–15)
 		TLSEnabled bool   `json:"tls_enabled,omitempty"` // enable TLS when connecting
 	}
 
@@ -164,8 +165,8 @@ func (c *ServerConf) Validate() error {
 }
 
 func (c *DatabaseConf) Validate() error {
-	if c.DBType == "Redis" && c.Redis.Addr == "" {
-		c.Redis.Addr = "localhost:6379"
+	if c.DBType == "Redis" && c.Service.Addr == "" {
+		c.Service.Addr = defaultKVServiceAddr
 	}
 	return nil
 }

--- a/api/authn/config.go
+++ b/api/authn/config.go
@@ -76,8 +76,18 @@ type (
 		DBConf     DatabaseConf `json:"db"`
 	}
 	DatabaseConf struct {
-		DBType   string `json:"type"`
-		Filepath string `json:"filepath"`
+		DBType   string    `json:"type"`
+		Filepath string    `json:"filepath,omitempty"`
+		Redis    RedisConf `json:"redis,omitempty"`
+	}
+
+	// RedisConf holds connection parameters for the Redis backend.
+	// All fields are overridable via environment variables.
+	RedisConf struct {
+		Addr       string `json:"addr"`                 // host:port, default "localhost:6379"
+		Password   string `json:"password,omitempty"`   //nolint:gosec // not a hardcoded cred
+		DB         int    `json:"db,omitempty"`         // Redis DB index (0–15), default 0
+		TLSEnabled bool   `json:"tls_enabled,omitempty"` // enable TLS when connecting
 	}
 
 	// TimeoutConf sets the default timeout for the HTTP client used by the auth manager
@@ -149,6 +159,13 @@ func (c *ServerConf) Validate() error {
 	}
 	if c.RSAKeyBits < minRSAKeyBits {
 		return fmt.Errorf("invalid auth.rsa_key_bits=%d, (must be >= %d)", c.RSAKeyBits, minRSAKeyBits)
+	}
+	return c.DBConf.Validate()
+}
+
+func (c *DatabaseConf) Validate() error {
+	if c.DBType == "Redis" && c.Redis.Addr == "" {
+		c.Redis.Addr = "localhost:6379"
 	}
 	return nil
 }

--- a/api/env/authn.go
+++ b/api/env/authn.go
@@ -29,8 +29,8 @@ const (
 	AisAuthAdminUsername  = "AIS_AUTHN_SU_NAME"
 	AisAuthAdminPassword  = "AIS_AUTHN_SU_PASS"
 
-	// Redis backend (used when auth.db.type = "Redis")
-	AisAuthRedisAddr     = "AIS_AUTHN_REDIS_ADDR"     // host:port, default localhost:6379
-	AisAuthRedisPassword = "AIS_AUTHN_REDIS_PASSWORD" //nolint:gosec // env var name, not a secret
-	AisAuthRedisDB       = "AIS_AUTHN_REDIS_DB"       // integer DB index, default 0
+	// External KV service backend (used when auth.db.type = "Redis" or similar)
+	AisAuthKVAddr     = "AIS_AUTHN_KV_ADDR"     // host:port
+	AisAuthKVPassword = "AIS_AUTHN_KV_PASSWORD" //nolint:gosec // env var name, not a secret
+	AisAuthKVDBIndex  = "AIS_AUTHN_KV_DB_INDEX" // integer DB index, default 0
 )

--- a/api/env/authn.go
+++ b/api/env/authn.go
@@ -28,4 +28,9 @@ const (
 	AisAuthPublicKey      = "AIS_AUTHN_PUBLIC_KEY"       // for asymmetric tokens
 	AisAuthAdminUsername  = "AIS_AUTHN_SU_NAME"
 	AisAuthAdminPassword  = "AIS_AUTHN_SU_PASS"
+
+	// Redis backend (used when auth.db.type = "Redis")
+	AisAuthRedisAddr     = "AIS_AUTHN_REDIS_ADDR"     // host:port, default localhost:6379
+	AisAuthRedisPassword = "AIS_AUTHN_REDIS_PASSWORD" //nolint:gosec // env var name, not a secret
+	AisAuthRedisDB       = "AIS_AUTHN_REDIS_DB"       // integer DB index, default 0
 )

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -41,6 +41,12 @@ type (
 	RSAKeyConfig struct {
 		Filepath string
 		Size     int
+		// AllowKeyGeneration controls whether the manager may auto-generate a new
+		// RSA key pair when none is found at Filepath.  Set to false when the key
+		// is externally provisioned (e.g. mounted from a Kubernetes Secret for
+		// multi-replica deployments): a missing key is then a configuration error,
+		// not a recoverable situation, and key rotation via the API is also blocked.
+		AllowKeyGeneration bool
 	}
 )
 
@@ -271,8 +277,39 @@ func (cm *ConfManager) GetSecret() cmn.Censored {
 
 func (cm *ConfManager) GetRSAConfig() *RSAKeyConfig {
 	keyFilePath := cos.GetEnvOrDefault(env.AisAuthPrivateKeyFile, filepath.Join(filepath.Dir(cm.filePath), fname.AuthNRSAKey))
+	// When using Redis, the key must be pre-provisioned and shared across all
+	// replicas (e.g. from a Kubernetes Secret).  Auto-generation would produce a
+	// different key on every replica, breaking cross-replica token validation.
+	allowGen := cm.GetDBType() != "Redis"
 	return &RSAKeyConfig{
-		Filepath: keyFilePath,
-		Size:     cm.conf.Load().Server.RSAKeyBits,
+		Filepath:           keyFilePath,
+		Size:               cm.conf.Load().Server.RSAKeyBits,
+		AllowKeyGeneration: allowGen,
 	}
+}
+
+//////////
+// Redis //
+//////////
+
+// GetRedisConf returns the Redis connection configuration, with env vars taking precedence over config file values.
+func (cm *ConfManager) GetRedisConf() *authn.RedisConf {
+	base := cm.conf.Load().Server.DBConf.Redis
+	c := base // copy
+
+	if v := os.Getenv(env.AisAuthRedisAddr); v != "" {
+		c.Addr = v
+	}
+	if v := os.Getenv(env.AisAuthRedisPassword); v != "" {
+		c.Password = v
+	}
+	if v := os.Getenv(env.AisAuthRedisDB); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			c.DB = n
+		}
+	}
+	if c.Addr == "" {
+		c.Addr = "localhost:6379"
+	}
+	return &c
 }

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -41,12 +41,10 @@ type (
 	RSAKeyConfig struct {
 		Filepath string
 		Size     int
-		// AllowKeyGeneration controls whether the manager may auto-generate a new
-		// RSA key pair when none is found at Filepath.  Set to false when the key
-		// is externally provisioned (e.g. mounted from a Kubernetes Secret for
-		// multi-replica deployments): a missing key is then a configuration error,
-		// not a recoverable situation, and key rotation via the API is also blocked.
-		AllowKeyGeneration bool
+		// ExternallyProvisioned signals that the RSA key is managed outside this process
+		// (e.g. mounted from a Kubernetes Secret). Auto-generation and API-driven rotation
+		// are both disabled: a missing key is a configuration error, not a recoverable state.
+		ExternallyProvisioned bool
 	}
 )
 
@@ -277,39 +275,37 @@ func (cm *ConfManager) GetSecret() cmn.Censored {
 
 func (cm *ConfManager) GetRSAConfig() *RSAKeyConfig {
 	keyFilePath := cos.GetEnvOrDefault(env.AisAuthPrivateKeyFile, filepath.Join(filepath.Dir(cm.filePath), fname.AuthNRSAKey))
-	// When using Redis, the key must be pre-provisioned and shared across all
-	// replicas (e.g. from a Kubernetes Secret).  Auto-generation would produce a
-	// different key on every replica, breaking cross-replica token validation.
-	allowGen := cm.GetDBType() != "Redis"
+	// When using an external KV backend (e.g. Redis), the RSA key must be pre-provisioned
+	// and shared across all replicas. Auto-generation would produce a different key on every
+	// replica, breaking cross-replica token validation.
+	externalKey := cm.GetDBType() == "Redis"
 	return &RSAKeyConfig{
-		Filepath:           keyFilePath,
-		Size:               cm.conf.Load().Server.RSAKeyBits,
-		AllowKeyGeneration: allowGen,
+		Filepath:              keyFilePath,
+		Size:                  cm.conf.Load().Server.RSAKeyBits,
+		ExternallyProvisioned: externalKey,
 	}
 }
 
-//////////
-// Redis //
-//////////
+////////////////////
+// KV service conf //
+////////////////////
 
-// GetRedisConf returns the Redis connection configuration, with env vars taking precedence over config file values.
-func (cm *ConfManager) GetRedisConf() *authn.RedisConf {
-	base := cm.conf.Load().Server.DBConf.Redis
+// GetKVServiceConf returns the external KV service connection configuration,
+// with env vars taking precedence over config file values.
+func (cm *ConfManager) GetKVServiceConf() *authn.KVServiceConf {
+	base := cm.conf.Load().Server.DBConf.Service
 	c := base // copy
 
-	if v := os.Getenv(env.AisAuthRedisAddr); v != "" {
+	if v := os.Getenv(env.AisAuthKVAddr); v != "" {
 		c.Addr = v
 	}
-	if v := os.Getenv(env.AisAuthRedisPassword); v != "" {
+	if v := os.Getenv(env.AisAuthKVPassword); v != "" {
 		c.Password = v
 	}
-	if v := os.Getenv(env.AisAuthRedisDB); v != "" {
+	if v := os.Getenv(env.AisAuthKVDBIndex); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
-			c.DB = n
+			c.DBIndex = n
 		}
-	}
-	if c.Addr == "" {
-		c.Addr = "localhost:6379"
 	}
 	return &c
 }

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -41,10 +41,6 @@ type (
 	RSAKeyConfig struct {
 		Filepath string
 		Size     int
-		// ExternallyProvisioned signals that the RSA key is managed outside this process
-		// (e.g. mounted from a Kubernetes Secret). Auto-generation and API-driven rotation
-		// are both disabled: a missing key is a configuration error, not a recoverable state.
-		ExternallyProvisioned bool
 	}
 )
 
@@ -275,14 +271,9 @@ func (cm *ConfManager) GetSecret() cmn.Censored {
 
 func (cm *ConfManager) GetRSAConfig() *RSAKeyConfig {
 	keyFilePath := cos.GetEnvOrDefault(env.AisAuthPrivateKeyFile, filepath.Join(filepath.Dir(cm.filePath), fname.AuthNRSAKey))
-	// When using an external KV backend (e.g. Redis), the RSA key must be pre-provisioned
-	// and shared across all replicas. Auto-generation would produce a different key on every
-	// replica, breaking cross-replica token validation.
-	externalKey := cm.GetDBType() == "Redis"
 	return &RSAKeyConfig{
-		Filepath:              keyFilePath,
-		Size:                  cm.conf.Load().Server.RSAKeyBits,
-		ExternallyProvisioned: externalKey,
+		Filepath: keyFilePath,
+		Size:     cm.conf.Load().Server.RSAKeyBits,
 	}
 }
 

--- a/cmd/authn/hserv.go
+++ b/cmd/authn/hserv.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/NVIDIA/aistore/api/apc"
 	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmd/authn/signing"
 	"github.com/NVIDIA/aistore/cmd/authn/tok"
 	"github.com/NVIDIA/aistore/cmn"
 	"github.com/NVIDIA/aistore/cmn/cos"
@@ -662,7 +663,7 @@ func (h *hserv) rotationHandler(w http.ResponseWriter, r *http.Request) {
 	err := h.mgr.rotateKey()
 	if err != nil {
 		status := http.StatusInternalServerError
-		if errors.Is(err, errInvalidRotation) {
+		if errors.Is(err, errInvalidRotation) || errors.Is(err, signing.ErrExternallyProvisioned) {
 			status = http.StatusBadRequest
 		}
 		cmn.WriteErr(w, r, err, status)

--- a/cmd/authn/hserv.go
+++ b/cmd/authn/hserv.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/NVIDIA/aistore/api/apc"
 	"github.com/NVIDIA/aistore/api/authn"
-	"github.com/NVIDIA/aistore/cmd/authn/signing"
 	"github.com/NVIDIA/aistore/cmd/authn/tok"
 	"github.com/NVIDIA/aistore/cmn"
 	"github.com/NVIDIA/aistore/cmn/cos"
@@ -663,7 +662,7 @@ func (h *hserv) rotationHandler(w http.ResponseWriter, r *http.Request) {
 	err := h.mgr.rotateKey()
 	if err != nil {
 		status := http.StatusInternalServerError
-		if errors.Is(err, errInvalidRotation) || errors.Is(err, signing.ErrExternallyProvisioned) {
+		if errors.Is(err, errInvalidRotation) {
 			status = http.StatusBadRequest
 		}
 		cmn.WriteErr(w, r, err, status)

--- a/cmd/authn/kvdb/kvdb.go
+++ b/cmd/authn/kvdb/kvdb.go
@@ -110,7 +110,7 @@ func CreateDriver(cm *config.ConfManager) *Driver {
 	case EmptyDB, BuntDB:
 		return &Driver{Driver: createBuntDB(cm.GetDBPath())}
 	case RedisDB:
-		return &Driver{Driver: createRedisDB(cm.GetRedisConf())}
+		return &Driver{Driver: createRedisDB(cm.GetKVServiceConf())}
 	default:
 		cos.ExitLogf(
 			"Invalid database type provided in config: %q. Supported types: %q, %q.",
@@ -128,7 +128,7 @@ func createBuntDB(path string) kvdb.Driver {
 	return driver
 }
 
-func createRedisDB(conf *authn.RedisConf) kvdb.Driver {
+func createRedisDB(conf *authn.KVServiceConf) kvdb.Driver {
 	driver, err := newRedisDriver(conf)
 	if err != nil {
 		cos.ExitLogf("Failed to connect to Redis: %v", err)

--- a/cmd/authn/kvdb/kvdb.go
+++ b/cmd/authn/kvdb/kvdb.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NVIDIA/aistore/api/authn"
 	"github.com/NVIDIA/aistore/cmd/authn/config"
 	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/cmn/kvdb"
@@ -21,6 +22,7 @@ type dbType string
 const (
 	EmptyDB dbType = ""
 	BuntDB  dbType = "BuntDB"
+	RedisDB dbType = "Redis"
 )
 
 const KeyMetadataVersion = 1
@@ -104,14 +106,15 @@ func (d *Driver) PersistKeyData(m *KeyData) error {
 }
 
 func CreateDriver(cm *config.ConfManager) *Driver {
-	dbPath := cm.GetDBPath()
 	switch dbType(cm.GetDBType()) {
 	case EmptyDB, BuntDB:
-		return &Driver{Driver: createBuntDB(dbPath)}
+		return &Driver{Driver: createBuntDB(cm.GetDBPath())}
+	case RedisDB:
+		return &Driver{Driver: createRedisDB(cm.GetRedisConf())}
 	default:
 		cos.ExitLogf(
-			"Invalid database type provided in config: %q. Currently supported database types are: %q.",
-			cm.GetDBType(), BuntDB,
+			"Invalid database type provided in config: %q. Supported types: %q, %q.",
+			cm.GetDBType(), BuntDB, RedisDB,
 		)
 		return nil
 	}
@@ -121,6 +124,14 @@ func createBuntDB(path string) kvdb.Driver {
 	driver, err := kvdb.NewBuntDB(path)
 	if err != nil {
 		cos.ExitLogf("Failed to init local database: %v", err)
+	}
+	return driver
+}
+
+func createRedisDB(conf *authn.RedisConf) kvdb.Driver {
+	driver, err := newRedisDriver(conf)
+	if err != nil {
+		cos.ExitLogf("Failed to connect to Redis: %v", err)
 	}
 	return driver
 }

--- a/cmd/authn/kvdb/redis.go
+++ b/cmd/authn/kvdb/redis.go
@@ -1,0 +1,194 @@
+// Package kvdb contains authN server code for interacting with a persistent key-value store
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package kvdb
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/cmn/kvdb"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/redis/go-redis/v9"
+)
+
+// redisDriver implements cmn/kvdb.Driver backed by Redis.
+//
+// Key layout mirrors BuntDB: every record is stored as a flat Redis string key
+// with the form  "<collection>##<key>",  where "##" is kvdb.CollectionSepa.
+// This allows zero-friction migration (dump BuntDB → RESTORE into Redis) and
+// keeps ParsePath / MakePath semantics identical across backends.
+type redisDriver struct {
+	client *redis.Client
+}
+
+// interface guard
+var _ kvdb.Driver = (*redisDriver)(nil)
+
+func newRedisDriver(conf *authn.RedisConf) (*redisDriver, error) {
+	opts := &redis.Options{
+		Addr:     conf.Addr,
+		Password: conf.Password,
+		DB:       conf.DB,
+	}
+	if conf.TLSEnabled {
+		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	client := redis.NewClient(opts)
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("redis: cannot connect to %q: %w", conf.Addr, err)
+	}
+	return &redisDriver{client: client}, nil
+}
+
+func (r *redisDriver) Close() error {
+	return r.client.Close()
+}
+
+func (r *redisDriver) Set(collection, key string, object any) (int, error) {
+	b := cos.MustMarshal(object)
+	return r.SetString(collection, key, string(b))
+}
+
+func (r *redisDriver) Get(collection, key string, object any) (int, error) {
+	s, code, err := r.GetString(collection, key)
+	if err != nil {
+		return code, err
+	}
+	if err := jsoniter.UnmarshalFromString(s, object); err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) SetString(collection, key, data string) (int, error) {
+	name := kvdb.MakePath(collection, key)
+	if err := r.client.Set(context.Background(), name, data, 0).Err(); err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) GetString(collection, key string) (string, int, error) {
+	name := kvdb.MakePath(collection, key)
+	val, err := r.client.Get(context.Background(), name).Result()
+	if err != nil {
+		if err == redis.Nil {
+			what := collection + " \"" + key + "\""
+			return "", http.StatusNotFound, cos.NewErrNotFound(nil, what)
+		}
+		return "", http.StatusInternalServerError, err
+	}
+	return val, http.StatusOK, nil
+}
+
+func (r *redisDriver) Delete(collection, key string) (int, error) {
+	name := kvdb.MakePath(collection, key)
+	n, err := r.client.Del(context.Background(), name).Result()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	if n == 0 {
+		what := collection + " \"" + key + "\""
+		return http.StatusNotFound, cos.NewErrNotFound(nil, what)
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) DeleteCollection(collection string) (int, error) {
+	pattern := kvdb.MakePath(collection, "*")
+	var cursor uint64
+	for {
+		keys, next, err := r.client.Scan(context.Background(), cursor, pattern, 256).Result()
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		if len(keys) > 0 {
+			if err := r.client.Del(context.Background(), keys...).Err(); err != nil {
+				return http.StatusInternalServerError, err
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return http.StatusOK, nil
+}
+
+// List returns the key portion (without collection prefix) of all entries whose
+// full path matches the given glob pattern within the collection.
+// If pattern contains no wildcards it is treated as a prefix ("prefix*").
+func (r *redisDriver) List(collection, pattern string) ([]string, int, error) {
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		pattern += "*"
+	}
+	keyPattern := kvdb.MakePath(collection, pattern)
+
+	var (
+		cursor uint64
+		keys   []string
+	)
+	for {
+		batch, next, err := r.client.Scan(context.Background(), cursor, keyPattern, 256).Result()
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		for _, fullKey := range batch {
+			_, k := kvdb.ParsePath(fullKey)
+			if k != "" {
+				keys = append(keys, k)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return keys, http.StatusOK, nil
+}
+
+// GetAll returns a map of key→value for all entries matching the pattern.
+// The SCAN+GET approach is safe: a key deleted between SCAN and GET is silently
+// skipped (it was being removed concurrently, which is a valid transient state).
+func (r *redisDriver) GetAll(collection, pattern string) (map[string]string, int, error) {
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		pattern += "*"
+	}
+	keyPattern := kvdb.MakePath(collection, pattern)
+
+	values := make(map[string]string)
+	var cursor uint64
+	for {
+		batch, next, err := r.client.Scan(context.Background(), cursor, keyPattern, 256).Result()
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+		for _, fullKey := range batch {
+			val, err := r.client.Get(context.Background(), fullKey).Result()
+			if err != nil {
+				if err == redis.Nil {
+					continue // key deleted between SCAN and GET
+				}
+				return nil, http.StatusInternalServerError, err
+			}
+			_, k := kvdb.ParsePath(fullKey)
+			if k != "" {
+				values[k] = val
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return values, http.StatusOK, nil
+}

--- a/cmd/authn/kvdb/redis.go
+++ b/cmd/authn/kvdb/redis.go
@@ -32,11 +32,11 @@ type redisDriver struct {
 // interface guard
 var _ kvdb.Driver = (*redisDriver)(nil)
 
-func newRedisDriver(conf *authn.RedisConf) (*redisDriver, error) {
+func newRedisDriver(conf *authn.KVServiceConf) (*redisDriver, error) {
 	opts := &redis.Options{
 		Addr:     conf.Addr,
 		Password: conf.Password,
-		DB:       conf.DB,
+		DB:       conf.DBIndex,
 	}
 	if conf.TLSEnabled {
 		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}

--- a/cmd/authn/signing/rsa_mgr.go
+++ b/cmd/authn/signing/rsa_mgr.go
@@ -111,8 +111,17 @@ func (r *RSAKeyManager) Init() error {
 		nlog.Infof("Loaded existing RSA private key from %s", path)
 		return nil
 	}
-	// No existing file -- generate and persist a new one
+	// No existing file -- generate and persist a new one, or fail if key must be
+	// externally provisioned (multi-replica / shared-key deployments).
 	if errors.Is(err, fs.ErrNotExist) {
+		if !r.conf.AllowKeyGeneration {
+			return fmt.Errorf(
+				"RSA key not found at %q and auto-generation is disabled; "+
+					"pre-provision the key and mount it at that path "+
+					"(see docs/authn.md for Kubernetes multi-replica setup)",
+				path,
+			)
+		}
 		nlog.Infof("No RSA key found on disk at %q, generating...", path)
 		return r.rotateKey()
 	}
@@ -442,6 +451,12 @@ func deriveKeyWithID(key *rsa.PrivateKey) (jwk.Key, error) {
 }
 
 func (r *RSAKeyManager) RotateKey() error {
+	if !r.conf.AllowKeyGeneration {
+		return errors.New(
+			"key rotation is not supported when the RSA key is externally provisioned; " +
+				"generate a new key, update the Kubernetes Secret, and redeploy",
+		)
+	}
 	nlog.Infof("Rotating RSA key")
 	return r.rotateKey()
 }

--- a/cmd/authn/signing/rsa_mgr.go
+++ b/cmd/authn/signing/rsa_mgr.go
@@ -54,6 +54,10 @@ const msgUninitialized = "init failed (fatal) or never called"
 
 var (
 	errEncryptedDataTooShort = errors.New("encrypted data is too short")
+
+	// ErrExternallyProvisioned is returned by RotateKey when the RSA key is externally
+	// managed. Callers should map this to a 400 Bad Request rather than 500.
+	ErrExternallyProvisioned = errors.New("key rotation is not supported when the RSA key is externally provisioned")
 )
 
 type (
@@ -114,13 +118,8 @@ func (r *RSAKeyManager) Init() error {
 	// No existing file -- generate and persist a new one, or fail if key must be
 	// externally provisioned (multi-replica / shared-key deployments).
 	if errors.Is(err, fs.ErrNotExist) {
-		if !r.conf.AllowKeyGeneration {
-			return fmt.Errorf(
-				"RSA key not found at %q and auto-generation is disabled; "+
-					"pre-provision the key and mount it at that path "+
-					"(see docs/authn.md for Kubernetes multi-replica setup)",
-				path,
-			)
+		if r.conf.ExternallyProvisioned {
+			return fmt.Errorf("RSA key not found at %q and auto-generation is disabled; pre-provision the key and mount it at that path", path)
 		}
 		nlog.Infof("No RSA key found on disk at %q, generating...", path)
 		return r.rotateKey()
@@ -451,11 +450,8 @@ func deriveKeyWithID(key *rsa.PrivateKey) (jwk.Key, error) {
 }
 
 func (r *RSAKeyManager) RotateKey() error {
-	if !r.conf.AllowKeyGeneration {
-		return errors.New(
-			"key rotation is not supported when the RSA key is externally provisioned; " +
-				"generate a new key, update the Kubernetes Secret, and redeploy",
-		)
+	if r.conf.ExternallyProvisioned {
+		return ErrExternallyProvisioned
 	}
 	nlog.Infof("Rotating RSA key")
 	return r.rotateKey()

--- a/cmd/authn/signing/rsa_mgr.go
+++ b/cmd/authn/signing/rsa_mgr.go
@@ -52,13 +52,7 @@ const (
 
 const msgUninitialized = "init failed (fatal) or never called"
 
-var (
-	errEncryptedDataTooShort = errors.New("encrypted data is too short")
-
-	// ErrExternallyProvisioned is returned by RotateKey when the RSA key is externally
-	// managed. Callers should map this to a 400 Bad Request rather than 500.
-	ErrExternallyProvisioned = errors.New("key rotation is not supported when the RSA key is externally provisioned")
-)
+var errEncryptedDataTooShort = errors.New("encrypted data is too short")
 
 type (
 	JWKSProvider interface {
@@ -115,12 +109,7 @@ func (r *RSAKeyManager) Init() error {
 		nlog.Infof("Loaded existing RSA private key from %s", path)
 		return nil
 	}
-	// No existing file -- generate and persist a new one, or fail if key must be
-	// externally provisioned (multi-replica / shared-key deployments).
 	if errors.Is(err, fs.ErrNotExist) {
-		if r.conf.ExternallyProvisioned {
-			return fmt.Errorf("RSA key not found at %q and auto-generation is disabled; pre-provision the key and mount it at that path", path)
-		}
 		nlog.Infof("No RSA key found on disk at %q, generating...", path)
 		return r.rotateKey()
 	}
@@ -450,9 +439,6 @@ func deriveKeyWithID(key *rsa.PrivateKey) (jwk.Key, error) {
 }
 
 func (r *RSAKeyManager) RotateKey() error {
-	if r.conf.ExternallyProvisioned {
-		return ErrExternallyProvisioned
-	}
 	nlog.Infof("Rotating RSA key")
 	return r.rotateKey()
 }
@@ -473,6 +459,10 @@ func (r *RSAKeyManager) GetPubKey() string {
 	return ""
 }
 
+// GetJWKS returns the current in-memory JWKS. The JWKS is populated at Init time
+// from the key on disk and is only updated when RotateKey is called. If the key
+// file changes externally (e.g. a mounted Secret is updated), the process must
+// be restarted to pick up the new key and refresh the JWKS.
 func (r *RSAKeyManager) GetJWKS() (jwk.Set, error) {
 	if c := r.bundle.Load(); c != nil {
 		return c.jwks.Clone()

--- a/cmn/kvdb/api.go
+++ b/cmn/kvdb/api.go
@@ -25,6 +25,15 @@ import (
 
 const CollectionSepa = "##"
 
+// MakePath constructs a unique database key from a collection name and a key.
+// Drivers must use this function so that ParsePath can correctly recover both parts.
+func MakePath(collection, key string) string {
+	if strings.HasSuffix(collection, CollectionSepa) {
+		return collection + key
+	}
+	return collection + CollectionSepa + key
+}
+
 type (
 	Driver interface {
 		// A driver should sync data with local drives on close

--- a/cmn/kvdb/bunt.go
+++ b/cmn/kvdb/bunt.go
@@ -65,17 +65,6 @@ func buntToCommonErr(err error, collection, key string) (int, error) {
 	}
 }
 
-// Create "unique" key from collection and key, so there was no trouble when
-// there is an overlap. E.g, if key and collection uses the same separator
-// for subkeys, two pairs ("abc", "def/ghi") and ("abc/def", "ghi") generate
-// the same full path. The function should make them different.
-func makePath(collection, key string) string {
-	if strings.HasSuffix(collection, "##") {
-		return collection + key
-	}
-	return collection + CollectionSepa + key
-}
-
 func (bd *BuntDriver) Close() error {
 	return bd.driver.Close()
 }
@@ -97,7 +86,7 @@ func (bd *BuntDriver) Get(collection, key string, object any) (int, error) {
 }
 
 func (bd *BuntDriver) SetString(collection, key, data string) (int, error) {
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.Update(func(tx *buntdb.Tx) error {
 		_, _, err := tx.Set(name, data, nil)
 		return err
@@ -107,7 +96,7 @@ func (bd *BuntDriver) SetString(collection, key, data string) (int, error) {
 
 func (bd *BuntDriver) GetString(collection, key string) (string, int, error) {
 	var value string
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		var err error
 		value, err = tx.Get(name)
@@ -118,7 +107,7 @@ func (bd *BuntDriver) GetString(collection, key string) (string, int, error) {
 }
 
 func (bd *BuntDriver) Delete(collection, key string) (int, error) {
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.Update(func(tx *buntdb.Tx) error {
 		_, err := tx.Delete(name)
 		return err
@@ -134,7 +123,7 @@ func (bd *BuntDriver) List(collection, pattern string) ([]string, int, error) {
 	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
 		pattern += "*"
 	}
-	filter = makePath(collection, pattern)
+	filter = MakePath(collection, pattern)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		tx.AscendKeys(filter, func(path, _ string) bool {
 			_, key := ParsePath(path)
@@ -174,7 +163,7 @@ func (bd *BuntDriver) GetAll(collection, pattern string) (map[string]string, int
 	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
 		pattern += "*"
 	}
-	filter = makePath(collection, pattern)
+	filter = MakePath(collection, pattern)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		tx.AscendKeys(filter, func(path, val string) bool {
 			_, key := ParsePath(path)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/seiflotfy/cuckoofilter v0.0.0-20240715131351-a2f2c23f1771
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	github.com/tidwall/buntdb v1.3.2
@@ -154,6 +155,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
+github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
@@ -364,6 +366,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=


### PR DESCRIPTION
Closes #273

Adds a Redis storage backend so multiple AuthN replicas can share all state (users, roles, clusters, revoked tokens, JWKS). BuntDB remains the default — opt-in via `auth.db.type = "Redis"`.

## Key changes

- `cmd/authn/kvdb/redis.go` — `kvdb.Driver` over Redis, same `collection##key` layout as BuntDB for easy migration
- `api/authn/config.go` / `api/env/authn.go` — `RedisConf` struct + `AIS_AUTHN_REDIS_ADDR/PASSWORD/DB` env vars
- `cmd/authn/signing/rsa_mgr.go` — fails fast at startup if the key file is missing in multi-replica mode (instead of silently generating a different key per replica); rotation API returns a clear error directing operators to update the Kubernetes Secret
- `cmn/kvdb/api.go` — exported `MakePath` shared across backends

## Deployment

Mount the same RSA key to all pods from a Kubernetes Secret, point all pods at the same Redis instance, set `replicas: N`.

## Not included (follow-up)

Tests for the Redis driver, Helm chart updates, live key rotation with Secret reload.