### PR TITLE
Update `ais_target_state_flags` Prometheus metric when rebalance or resilver is interrupted

### DIFF
--- a/ais/target.go
+++ b/ais/target.go
@@ -428,7 +428,7 @@ func (t *target) Run() error {
 	// When `auth.intra_cluster.enabled`, restarted node must _not_ originate signed traffic to a peer
 	// until that peer has received an (updated version of) Smap containing the node's (current)
 	// verifying key.
-	fatalErr, writeErr := t.checkRestarted(config)
+	fatalErr, writeErr := t.checkStartupMarkers(config)
 	if fatalErr != nil {
 		cos.ExitLog(fatalErr)
 	}
@@ -679,7 +679,7 @@ func rxAnyStream(w http.ResponseWriter, r *http.Request) {
 	transport.RxAnyStream(w, r)
 }
 
-func (t *target) checkRestarted(config *cmn.Config) (fatalErr, writeErr error) {
+func (t *target) checkStartupMarkers(config *cmn.Config) (fatalErr, writeErr error) {
 	if fs.MarkerExists(fname.NodeRestartedMarker) {
 		red := redial{t: t, dialTout: config.Timeout.CplaneOperation.D(), totalTout: config.Timeout.MaxKeepalive.D()}
 		if red.acked() {
@@ -688,6 +688,12 @@ func (t *target) checkRestarted(config *cmn.Config) (fatalErr, writeErr error) {
 		}
 		t.statsT.SetFlag(cos.NodeAlerts, cos.NodeRestarted)
 		fs.PersistMarker(fname.NodeRestartedPrev, false /*quiet*/)
+	}
+	if fs.MarkerExists(fname.RebalanceMarker) {
+		t.statsT.SetFlag(cos.NodeAlerts, cos.RebalanceInterrupted)
+	}
+	if fs.MarkerExists(fname.ResilverMarker) {
+		t.statsT.SetFlag(cos.NodeAlerts, cos.ResilverInterrupted)
 	}
 	fatalErr, writeErr = fs.PersistMarker(fname.NodeRestartedMarker, false /*quiet*/)
 	return

--- a/fs/persistent_md.go
+++ b/fs/persistent_md.go
@@ -118,6 +118,18 @@ func RemoveMarker(marker string, stup cos.StatsUpdater, stopping bool) (ok bool)
 			}
 		}
 	}
+
+	if !ok {
+		switch marker {
+		case fname.RebalanceMarker:
+			stup.SetClrFlag(cos.NodeAlerts, cos.RebalanceInterrupted, cos.Rebalancing)
+		case fname.ResilverMarker:
+			stup.SetClrFlag(cos.NodeAlerts, cos.ResilverInterrupted, cos.Resilvering)
+		}
+
+		return ok
+	}
+
 	switch marker {
 	case fname.RebalanceMarker:
 		stup.ClrFlag(cos.NodeAlerts, cos.RebalanceInterrupted|cos.Rebalancing)

--- a/fs/persistent_md_test.go
+++ b/fs/persistent_md_test.go
@@ -5,8 +5,12 @@
 package fs_test
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/cmn/fname"
 	"github.com/NVIDIA/aistore/core/mock"
 	"github.com/NVIDIA/aistore/fs"
@@ -68,4 +72,133 @@ func TestMarkers(t *testing.T) {
 		markerEntry{marker: fname.RebalanceMarker, exists: false},
 		markerEntry{marker: fname.ResilverMarker, exists: false},
 	)
+}
+
+// flagTrackingStats implements cos.StatsUpdater and records flag operations
+// so tests can verify that RemoveMarker sets/clears the correct alerts.
+type flagTrackingStats struct {
+	mu           sync.Mutex
+	setClrCalls  []flagSetClrCall
+	setFlagCalls []flagSetCall
+	clrFlagCalls []flagClrCall
+}
+
+type (
+	flagSetClrCall struct {
+		name string
+		set  cos.NodeStateFlags
+		clr  cos.NodeStateFlags
+	}
+	flagSetCall struct {
+		name  string
+		flags cos.NodeStateFlags
+	}
+	flagClrCall struct {
+		name  string
+		flags cos.NodeStateFlags
+	}
+)
+
+var _ cos.StatsUpdater = (*flagTrackingStats)(nil)
+
+func (*flagTrackingStats) Get(string) int64                  { return 0 }
+func (*flagTrackingStats) Inc(string)                        {}
+func (*flagTrackingStats) IncWith(string, map[string]string) {}
+func (*flagTrackingStats) Add(string, int64)                 {}
+func (*flagTrackingStats) Observe(string, float64)           {}
+func (*flagTrackingStats) AddWith(...cos.NamedVal64)         {}
+
+func (s *flagTrackingStats) SetFlag(name string, flags cos.NodeStateFlags) {
+	s.mu.Lock()
+	s.setFlagCalls = append(s.setFlagCalls, flagSetCall{name, flags})
+	s.mu.Unlock()
+}
+
+func (s *flagTrackingStats) ClrFlag(name string, flags cos.NodeStateFlags) {
+	s.mu.Lock()
+	s.clrFlagCalls = append(s.clrFlagCalls, flagClrCall{name, flags})
+	s.mu.Unlock()
+}
+
+func (s *flagTrackingStats) SetClrFlag(name string, set, clr cos.NodeStateFlags) {
+	s.mu.Lock()
+	s.setClrCalls = append(s.setClrCalls, flagSetClrCall{name, set, clr})
+	s.mu.Unlock()
+}
+
+// makeMarkerUnremovable creates a non-empty directory at each marker path so
+// that os.Remove (and thus cos.RemoveFile) fails with ENOTEMPTY — an error
+// that cos.RemoveFile does NOT suppress (it only suppresses ENOENT).
+func makeMarkerUnremovable(t *testing.T, mpaths fs.MPI, marker string) {
+	for _, mi := range mpaths {
+		markerDir := filepath.Join(mi.Path, fname.MarkersDir, marker)
+		tassert.CheckFatal(t, os.MkdirAll(markerDir, 0o755))
+		f, err := os.Create(filepath.Join(markerDir, "block"))
+		tassert.CheckFatal(t, err)
+		tassert.CheckFatal(t, f.Close())
+	}
+}
+
+// cleanupMarkerDirs removes any marker directories (created by makeMarkerUnremovable)
+// before RemoveMpaths, so that _moveMarkers doesn't try to copy a directory and
+// hit the nil FSHC during test teardown.
+func cleanupMarkerDirs(t *testing.T, mpaths fs.MPI) {
+	for _, mi := range mpaths {
+		for _, marker := range []string{fname.RebalanceMarker, fname.ResilverMarker} {
+			tassert.CheckError(t, os.RemoveAll(filepath.Join(mi.Path, fname.MarkersDir, marker)))
+		}
+	}
+}
+
+func TestRemoveMarkerFailure(t *testing.T) {
+	const mpathsCnt = 3
+	mpaths := tools.PrepareMountPaths(t, mpathsCnt)
+	defer func() {
+		cleanupMarkerDirs(t, mpaths)
+		tools.RemoveMpaths(t, mpaths)
+	}()
+
+	t.Run("rebalance", func(t *testing.T) {
+		tracker := &flagTrackingStats{}
+		makeMarkerUnremovable(t, mpaths, fname.RebalanceMarker)
+
+		ok := fs.RemoveMarker(fname.RebalanceMarker, tracker, true /*stopping*/)
+		tassert.Fatalf(t, !ok, "expected RemoveMarker to return false on failure")
+
+		tassert.Fatalf(t, len(tracker.setClrCalls) == 1,
+			"expected 1 SetClrFlag call, got %d", len(tracker.setClrCalls))
+		call := tracker.setClrCalls[0]
+		tassert.Fatalf(t, call.name == cos.NodeAlerts,
+			"expected name %q, got %q", cos.NodeAlerts, call.name)
+		tassert.Fatalf(t, call.set == cos.RebalanceInterrupted,
+			"expected set flag RebalanceInterrupted, got %v", call.set)
+		tassert.Fatalf(t, call.clr == cos.Rebalancing,
+			"expected clr flag Rebalancing, got %v", call.clr)
+		tassert.Fatalf(t, len(tracker.setFlagCalls) == 0,
+			"expected no SetFlag calls, got %d", len(tracker.setFlagCalls))
+		tassert.Fatalf(t, len(tracker.clrFlagCalls) == 0,
+			"expected no ClrFlag calls, got %d", len(tracker.clrFlagCalls))
+	})
+
+	t.Run("resilver", func(t *testing.T) {
+		tracker := &flagTrackingStats{}
+		makeMarkerUnremovable(t, mpaths, fname.ResilverMarker)
+
+		ok := fs.RemoveMarker(fname.ResilverMarker, tracker, true /*stopping*/)
+		tassert.Fatalf(t, !ok, "expected RemoveMarker to return false on failure")
+
+		tassert.Fatalf(t, len(tracker.setClrCalls) == 1,
+			"expected 1 SetClrFlag call, got %d", len(tracker.setClrCalls))
+		call := tracker.setClrCalls[0]
+		tassert.Fatalf(t, call.name == cos.NodeAlerts,
+			"expected name %q, got %q", cos.NodeAlerts, call.name)
+		tassert.Fatalf(t, call.set == cos.ResilverInterrupted,
+			"expected set flag ResilverInterrupted, got %v", call.set)
+		tassert.Fatalf(t, call.clr == cos.Resilvering,
+			"expected clr flag Resilvering, got %v", call.clr)
+		tassert.Fatalf(t, len(tracker.setFlagCalls) == 0,
+			"expected no SetFlag calls, got %d", len(tracker.setFlagCalls))
+		tassert.Fatalf(t, len(tracker.clrFlagCalls) == 0,
+			"expected no ClrFlag calls, got %d", len(tracker.clrFlagCalls))
+	})
 }

--- a/reb/cleanup.go
+++ b/reb/cleanup.go
@@ -151,10 +151,15 @@ func (reb *Reb) RunCleanup(smap *meta.Smap, extArgs *ExtArgs, force bool) {
 		nlog.Warningln(logHdr, "initializing cleanup - limited scope: [", extArgs.Bck.Cname(extArgs.Prefix), "]")
 	}
 
+	// starting cleanup: set Rebalancing and clear a stale RebalanceInterrupted
+	// left over from a previously aborted/interrupted run (or a node restart)
+	extArgs.Tstats.SetClrFlag(cos.NodeAlerts, cos.Rebalancing, cos.RebalanceInterrupted)
+
 	// walk mpaths with the cleanup visitor
 	reb.runCleanup(clnArgs)
 
 	reb.finiCleanup(clnArgs, extArgs.Tstats)
+	extArgs.Tstats.ClrFlag(cos.NodeAlerts, cos.Rebalancing)
 	clnArgs.xreb.FinalCtlMsg()
 }
 
@@ -215,10 +220,15 @@ func (reb *Reb) finiCleanup(clnArgs *clnArgs, tstats cos.StatsUpdater) {
 		ecnt = xreb.ErrCnt()
 	)
 	if !xreb.IsAborted() {
+		// TODO: fix race condition where a stop request arrives after Quiesce() returns but before xreb.Finish().
+		// The marker is already removed here, but the xaction is still running, so the stop is accepted.
+		// Finish() then records it as aborted while the marker and Prometheus flag indicate success.
 		if fs.RemoveMarker(fname.RebalanceMarker, tstats, false /*stopping*/) {
 			nlog.Infoln(clnArgs.logHdr, "removed marker ok")
 		}
 		_ = fs.RemoveMarker(fname.NodeRestartedPrev, tstats, false /*stopping*/)
+	} else {
+		tstats.SetFlag(cos.NodeAlerts, cos.RebalanceInterrupted)
 	}
 
 	reb.mu.Lock()

--- a/reb/globrun.go
+++ b/reb/globrun.go
@@ -306,7 +306,9 @@ func (reb *Reb) Run(smap *meta.Smap, extArgs *ExtArgs) {
 	}
 	onGFN()
 
-	extArgs.Tstats.SetFlag(cos.NodeAlerts, cos.Rebalancing)
+	// starting a new rebalance: set Rebalancing and clear a stale RebalanceInterrupted
+	// left over from a previously aborted/interrupted run (or a node restart)
+	extArgs.Tstats.SetClrFlag(cos.NodeAlerts, cos.Rebalancing, cos.RebalanceInterrupted)
 
 	// run: nwp workers (if any), lazy deletion, rebalance joggers (no-EC[, EC))
 	if !rargs.ecUsed {
@@ -605,10 +607,15 @@ func (reb *Reb) fini(rargs *rargs, err error, tstats cos.StatsUpdater) {
 
 	// cleanup markers
 	if que != core.QuiAborted && que != core.QuiTimeout {
+		// TODO: fix race condition where a stop request arrives after Quiesce() returns but before xreb.Finish().
+		// The marker is already removed here, but the xaction is still running, so the stop is accepted.
+		// Finish() then records it as aborted while the marker and Prometheus flag indicate success.
 		if fs.RemoveMarker(fname.RebalanceMarker, tstats, false /*stopping*/) {
 			nlog.Infoln(rargs.logHdr, "removed marker ok")
 		}
 		_ = fs.RemoveMarker(fname.NodeRestartedPrev, tstats, false /*stopping*/)
+	} else {
+		tstats.SetFlag(cos.NodeAlerts, cos.RebalanceInterrupted)
 	}
 
 	// Close and Rx-unregister data mover:

--- a/res/resilver.go
+++ b/res/resilver.go
@@ -122,6 +122,10 @@ func (res *Res) Run(args *Args, tstats cos.StatsUpdater) {
 		return
 	}
 
+	// starting a new resilver: set Resilvering and clear a stale ResilverInterrupted
+	// left over from a previously aborted/interrupted run (or a node restart)
+	tstats.SetClrFlag(cos.NodeAlerts, cos.Resilvering, cos.ResilverInterrupted)
+
 	// jgroup
 	var (
 		jgroup    *mpather.Jgroup
@@ -172,6 +176,8 @@ func (res *Res) Run(args *Args, tstats cos.StatsUpdater) {
 	}
 
 	xres.Finish()
+
+	tstats.ClrFlag(cos.NodeAlerts, cos.Resilvering)
 
 	res.mu.Lock()
 	if xres == res.xres {
@@ -237,13 +243,17 @@ func (res *Res) initRenew(args *Args) *xs.Resilver {
 func wait(jgroup *mpather.Jgroup, xres *xs.Resilver, tstats cos.StatsUpdater) {
 	for {
 		select {
-		case <-xres.ChanAbort():
-			_ = jgroup.Stop()
-			return
 		case <-jgroup.ListenFinished():
+			// TODO: there's a potential race condition if a "stop" request is received after this function call but
+			// before xres.Finish(). In this case, the marker and Prometheus flag indicate success, while Finish()
+			// records the resilver as aborted.
 			if fs.RemoveMarker(fname.ResilverMarker, tstats, false /*stopping*/) {
 				nlog.Infoln(core.T.String()+":", xres.Name(), "removed marker ok")
 			}
+			return
+		case <-xres.ChanAbort():
+			_ = jgroup.Stop()
+			tstats.SetFlag(cos.NodeAlerts, cos.ResilverInterrupted)
 			return
 		}
 	}


### PR DESCRIPTION
I would like to use the `RebalanceInterrupted` bit of the `ais_target_state_flags` Prometheus metric to monitor rebalance stability. However, in the current code it's never set to 1.

Changes:
* The `RebalanceInterrupted` bit in the `ais_target_state_flags` Prometheus metric now gets set when a rebalance is interrupted. It gets cleared when a new rebalance starts.
* Launching a rebalance with the `--cleanup` flag sets the `Rebalancing` bit in the `ais_target_state_flags` Prometheus metric
* Launching a rebalance with the `--cleanup` flag clears the `rebalance-interrupted` state in `ais show cluster`
* Launching a rebalance with the `--cleanup` flag sets the `Rebalancing` bit in Prometheus
* The `ResilverInterrupted` bit in the `ais_target_state_flags` Prometheus metric now gets set when a resilver is interrupted. It gets cleared when a new resilver starts.