### PR TITLE
authn: externally provisioned RSA key config

### DIFF
--- a/api/authn/config.go
+++ b/api/authn/config.go
@@ -40,6 +40,14 @@ const (
 	defaultPort             = 52001
 )
 
+// RSA key management modes for auth.rsa.mode
+const (
+	// RSAModeExternal signals that the RSA key is managed outside this process
+	// (e.g. mounted from a secret manager or HSM). Auto-generation and API-driven
+	// rotation are disabled; a missing key file is a fatal configuration error.
+	RSAModeExternal = "external"
+)
+
 type (
 	Config struct {
 		Server  ServerConf  `json:"auth"`
@@ -70,10 +78,14 @@ type (
 		// Also used to determine max-age for client caches of JWKS
 		Expire cos.Duration `json:"expiration_time"`
 		// Only used for validating RSA public key against AIS clusters
-		PubKey *string `json:"public_key"`
-		// Size of RSA private key to generate
-		RSAKeyBits int          `json:"rsa_key_bits"`
-		DBConf     DatabaseConf `json:"db"`
+		PubKey *string      `json:"public_key"`
+		RSA    RSAConf      `json:"rsa"`
+		DBConf DatabaseConf `json:"db"`
+	}
+	RSAConf struct {
+		Bits int `json:"bits,omitempty"`
+		// "external": key is managed outside this process; auto-generation and API rotation are disabled
+		Mode string `json:"mode,omitempty"`
 	}
 	DatabaseConf struct {
 		DBType   string `json:"type"`
@@ -144,11 +156,14 @@ func (c *ServerConf) Validate() error {
 	if c.Expire < minAuthExpiration {
 		return fmt.Errorf("invalid auth.expiration_time=%s, (expected 0 (infinite) or >= %s)", c.Expire, minAuthExpiration)
 	}
-	if c.RSAKeyBits == 0 {
-		c.RSAKeyBits = defaultRSAKeyBits
+	if c.RSA.Bits == 0 {
+		c.RSA.Bits = defaultRSAKeyBits
 	}
-	if c.RSAKeyBits < minRSAKeyBits {
-		return fmt.Errorf("invalid auth.rsa_key_bits=%d, (must be >= %d)", c.RSAKeyBits, minRSAKeyBits)
+	if c.RSA.Bits < minRSAKeyBits {
+		return fmt.Errorf("invalid auth.rsa.bits=%d (must be >= %d)", c.RSA.Bits, minRSAKeyBits)
+	}
+	if c.RSA.Mode != "" && c.RSA.Mode != RSAModeExternal {
+		return fmt.Errorf("invalid auth.rsa.mode=%q (valid values: %q or empty)", c.RSA.Mode, RSAModeExternal)
 	}
 	return nil
 }

--- a/api/authn/config_internal_test.go
+++ b/api/authn/config_internal_test.go
@@ -41,11 +41,16 @@ func TestConfigValidateValid(t *testing.T) {
 	tassert.CheckFatal(t, c.Validate())
 	tassert.Errorf(t, c.Log.FlushInterval == defaultLogFlushInterval, "expected FlushInterval default, got %v", c.Log.FlushInterval)
 
-	// zero RSAKeyBits gets default
+	// zero RSA.Bits gets default
 	c = validConfig()
-	c.Server.RSAKeyBits = 0
+	c.Server.RSA.Bits = 0
 	tassert.CheckFatal(t, c.Validate())
-	tassert.Errorf(t, c.Server.RSAKeyBits == defaultRSAKeyBits, "expected RSAKeyBits default, got %d", c.Server.RSAKeyBits)
+	tassert.Errorf(t, c.Server.RSA.Bits == defaultRSAKeyBits, "expected RSA.Bits default, got %d", c.Server.RSA.Bits)
+
+	// external mode is accepted
+	c = validConfig()
+	c.Server.RSA.Mode = RSAModeExternal
+	tassert.CheckFatal(t, c.Validate())
 
 	// valid external url is parsed
 	c = validConfig()
@@ -59,7 +64,8 @@ func TestConfigValidateInvalid(t *testing.T) {
 		modify func(*Config)
 	}{
 		{"expire too short", func(c *Config) { c.Server.Expire = minAuthExpiration - 1 }},
-		{"RSA bits too small", func(c *Config) { c.Server.RSAKeyBits = minRSAKeyBits - 1 }},
+		{"RSA bits too small", func(c *Config) { c.Server.RSA.Bits = minRSAKeyBits - 1 }},
+		{"RSA mode invalid", func(c *Config) { c.Server.RSA.Mode = "auto" }},
 		{"bad log level", func(c *Config) { c.Log.Level = "verbose" }},
 		{"log level too low", func(c *Config) { c.Log.Level = "-1" }},
 		{"log level too high", func(c *Config) { c.Log.Level = "6" }},

--- a/api/env/authn.go
+++ b/api/env/authn.go
@@ -9,23 +9,24 @@ package env
 
 //nolint:gosec // false positive G101
 const (
-	AisAuthEnabled        = "AIS_AUTHN_ENABLED"
-	AisAuthURL            = "AIS_AUTHN_URL"
-	AisAuthTokenFile      = "AIS_AUTHN_TOKEN_FILE" // fully qualified
-	AisAuthToken          = "AIS_AUTHN_TOKEN"      // Only the JWT token itself (excluding the file and JSON)
-	AisAuthConfDir        = "AIS_AUTHN_CONF_DIR"   // contains AuthN config and tokens DB
-	AisAuthLogDir         = "AIS_AUTHN_LOG_DIR"
-	AisAuthLogLevel       = "AIS_AUTHN_LOG_LEVEL"
-	AisAuthExternalURL    = "AIS_AUTHN_EXTERNAL_URL"
-	AisAuthPort           = "AIS_AUTHN_PORT"
-	AisAuthTTL            = "AIS_AUTHN_TTL"
-	AisAuthUseHTTPS       = "AIS_AUTHN_USE_HTTPS"
-	AisAuthServerCrt      = "AIS_SERVER_CRT"
-	AisAuthServerKey      = "AIS_SERVER_KEY"
-	AisAuthSecretKey      = "AIS_AUTHN_SECRET_KEY"
-	AisAuthPrivateKeyFile = "AIS_AUTHN_PRIVATE_KEY_FILE"
-	AisAuthPrivateKeyPass = "AIS_AUTHN_PRIVATE_KEY_PASS" // optional passphrase for encrypting private key on disk
-	AisAuthPublicKey      = "AIS_AUTHN_PUBLIC_KEY"       // for asymmetric tokens
-	AisAuthAdminUsername  = "AIS_AUTHN_SU_NAME"
-	AisAuthAdminPassword  = "AIS_AUTHN_SU_PASS"
+	AisAuthEnabled               = "AIS_AUTHN_ENABLED"
+	AisAuthURL                   = "AIS_AUTHN_URL"
+	AisAuthTokenFile             = "AIS_AUTHN_TOKEN_FILE" // fully qualified
+	AisAuthToken                 = "AIS_AUTHN_TOKEN"      // Only the JWT token itself (excluding the file and JSON)
+	AisAuthConfDir               = "AIS_AUTHN_CONF_DIR"   // contains AuthN config and tokens DB
+	AisAuthLogDir                = "AIS_AUTHN_LOG_DIR"
+	AisAuthLogLevel              = "AIS_AUTHN_LOG_LEVEL"
+	AisAuthExternalURL           = "AIS_AUTHN_EXTERNAL_URL"
+	AisAuthPort                  = "AIS_AUTHN_PORT"
+	AisAuthTTL                   = "AIS_AUTHN_TTL"
+	AisAuthUseHTTPS              = "AIS_AUTHN_USE_HTTPS"
+	AisAuthServerCrt             = "AIS_SERVER_CRT"
+	AisAuthServerKey             = "AIS_SERVER_KEY"
+	AisAuthSecretKey             = "AIS_AUTHN_SECRET_KEY"
+	AisAuthPrivateKeyFile        = "AIS_AUTHN_PRIVATE_KEY_FILE"
+	AisAuthPrivateKeyPass        = "AIS_AUTHN_PRIVATE_KEY_PASS" // optional passphrase for encrypting private key on disk
+	AisAuthPublicKey             = "AIS_AUTHN_PUBLIC_KEY"       // for asymmetric tokens
+	AisAuthAdminUsername         = "AIS_AUTHN_SU_NAME"
+	AisAuthAdminPassword         = "AIS_AUTHN_SU_PASS"
+	AisAuthRSAMode = "AIS_AUTHN_RSA_MODE" // RSA key management mode; set to "external" to disable auto-generation and API rotation
 )

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -41,6 +41,9 @@ type (
 	RSAKeyConfig struct {
 		Filepath string
 		Size     int
+		// ExternallyProvisioned is true when auth.rsa.mode is "external" (or AIS_AUTHN_RSA_MODE=external).
+		// A missing key file is a fatal configuration error; key rotation via API is rejected.
+		ExternallyProvisioned bool
 	}
 )
 
@@ -271,8 +274,10 @@ func (cm *ConfManager) GetSecret() cmn.Censored {
 
 func (cm *ConfManager) GetRSAConfig() *RSAKeyConfig {
 	keyFilePath := cos.GetEnvOrDefault(env.AisAuthPrivateKeyFile, filepath.Join(filepath.Dir(cm.filePath), fname.AuthNRSAKey))
+	mode := cos.GetEnvOrDefault(env.AisAuthRSAMode, cm.conf.Load().Server.RSA.Mode)
 	return &RSAKeyConfig{
-		Filepath: keyFilePath,
-		Size:     cm.conf.Load().Server.RSAKeyBits,
+		Filepath:              keyFilePath,
+		Size:                  cm.conf.Load().Server.RSA.Bits,
+		ExternallyProvisioned: mode == authn.RSAModeExternal,
 	}
 }

--- a/cmd/authn/hserv.go
+++ b/cmd/authn/hserv.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/NVIDIA/aistore/api/apc"
 	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmd/authn/signing"
 	"github.com/NVIDIA/aistore/cmd/authn/tok"
 	"github.com/NVIDIA/aistore/cmn"
 	"github.com/NVIDIA/aistore/cmn/cos"
@@ -662,7 +663,7 @@ func (h *hserv) rotationHandler(w http.ResponseWriter, r *http.Request) {
 	err := h.mgr.rotateKey()
 	if err != nil {
 		status := http.StatusInternalServerError
-		if errors.Is(err, errInvalidRotation) {
+		if errors.Is(err, errInvalidRotation) || errors.Is(err, signing.ErrExternallyProvisioned) {
 			status = http.StatusBadRequest
 		}
 		cmn.WriteErr(w, r, err, status)

--- a/cmd/authn/signing/rsa_mgr.go
+++ b/cmd/authn/signing/rsa_mgr.go
@@ -54,6 +54,10 @@ const msgUninitialized = "init failed (fatal) or never called"
 
 var (
 	errEncryptedDataTooShort = errors.New("encrypted data is too short")
+
+	// ErrExternallyProvisioned is returned by RotateKey when the RSA key is externally
+	// managed. Callers should map this to a 400 Bad Request rather than 500.
+	ErrExternallyProvisioned = errors.New("key rotation is not supported when the RSA key is externally provisioned")
 )
 
 type (
@@ -98,8 +102,10 @@ func NewRSAKeyManager(conf *config.RSAKeyConfig, passphrase cmn.Censored, db kvd
 	}
 }
 
-// Init sets up an RSA key pair, using one from disk if provided
-// Must only be called at init time -- key rotation not yet implemented
+// Init loads or generates the RSA key pair used for token signing. Must be called once at startup.
+// When ExternallyProvisioned, a missing key file is a fatal error and API rotation is rejected.
+// To pick up an externally rotated key, replace the file on disk and restart the process;
+// live reload without a restart is not supported.
 func (r *RSAKeyManager) Init() error {
 	if r.db == nil {
 		return errors.New("storage driver required for RSA key manager")
@@ -111,8 +117,11 @@ func (r *RSAKeyManager) Init() error {
 		nlog.Infof("Loaded existing RSA private key from %s", path)
 		return nil
 	}
-	// No existing file -- generate and persist a new one
+	// No existing file -- fail if key is externally provisioned, otherwise generate one.
 	if errors.Is(err, fs.ErrNotExist) {
+		if r.conf.ExternallyProvisioned {
+			return fmt.Errorf("RSA key not found at %q and auto-generation is disabled; pre-provision the key and mount it at that path", path)
+		}
 		nlog.Infof("No RSA key found on disk at %q, generating...", path)
 		return r.rotateKey()
 	}
@@ -442,6 +451,9 @@ func deriveKeyWithID(key *rsa.PrivateKey) (jwk.Key, error) {
 }
 
 func (r *RSAKeyManager) RotateKey() error {
+	if r.conf.ExternallyProvisioned {
+		return ErrExternallyProvisioned
+	}
 	nlog.Infof("Rotating RSA key")
 	return r.rotateKey()
 }


### PR DESCRIPTION
## Summary

Adds `auth.externally_provisioned` (config file) / `AIS_AUTHN_EXTERNALLY_PROVISIONED` (env var) to signal that the RSA signing key is managed outside the AuthN process.

When set:
- A missing key file at startup is a **fatal configuration error**, not a recoverable state (no auto-generation)
- `POST /v1/auth/keys/rotate` returns **400 Bad Request** via the `signing.ErrExternallyProvisioned` sentinel rather than 500

This is useful for any deployment requiring a shared, pre-provisioned key — multi-replica setups, secret managers, HSMs, etc. — and is **independent of the storage backend** in use.

Split out from #290 per reviewer request.

## Test plan
- [ ] Start AuthN with `externally_provisioned: true` and a valid key file — should load normally
- [ ] Start AuthN with `externally_provisioned: true` and no key file — should exit with a clear error
- [ ] Call `POST /v1/auth/keys/rotate` with `externally_provisioned: true` — should return 400
- [ ] Start AuthN with `AIS_AUTHN_EXTERNALLY_PROVISIONED=true` env var — env should override config file value