### PR TITLE
python/etl: stream Flask no-FQN hpush PUT

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,18 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
 
 ## Unreleased
 
+### Fixed
+
+- ETL `FlaskServer`: stream no-FQN `hpush` PUTs in constant memory via Werkzeug
+  `request.stream` (with chunked drain-on-close to keep keep-alive sockets
+  clean); release upstream `hpull` GET connections through `_ResponseRawReader`;
+  forward upstream HTTP error statuses as-is instead of collapsing them to 502.
+- ETL `FlaskServer` joins the **ETL → AIS retry contract** (streaming no-FQN
+  PUT): one-shot bail emits HTTP 503 with
+  `Ais-Etl-Retry-Reason: direct-put-transient` so AIS retries against the
+  replayable LOM-backed source; replayable-exhausted cases keep emitting 502.
+  Matches the behavior already in `FastAPIServer` and `HTTPMultiThreadedServer`.
+
 ## [1.24.0] - 2026-05-08
 
 ### Changed

--- a/python/aistore/sdk/errors.py
+++ b/python/aistore/sdk/errors.py
@@ -172,14 +172,14 @@ class ETLDirectPutTransientError(Exception):
     that is safe to retry (connection lost before a response was received).
 
     AIS-side retry contract: when the ETL bails *without* trying locally —
-    i.e., the source body is one-shot (currently only the streaming no-FQN
-    PUT path on FastAPI/HTTP webservers) — `bail_without_local_retry` is
-    set to `True` and the webserver responds with HTTP 503 and the
-    `Ais-Etl-Retry-Reason: direct-put-transient` header. AIS treats that
-    pair as a soft error and retries the whole PUT against the replayable
-    LOM-backed source. When `bail_without_local_retry` is `False` (the ETL
-    exhausted its own retry budget), the webserver continues to respond
-    with HTTP 502 — adding more retries on top would just be amplification.
+    i.e., the source body is one-shot (the streaming no-FQN PUT path) —
+    `bail_without_local_retry` is set to `True` and the webserver responds
+    with HTTP 503 and the `Ais-Etl-Retry-Reason: direct-put-transient`
+    header. AIS treats that pair as a soft error and retries the whole PUT
+    against the replayable LOM-backed source. When `bail_without_local_retry`
+    is `False` (the ETL exhausted its own retry budget), the webserver
+    continues to respond with HTTP 502 — adding more retries on top would
+    just be amplification.
     """
 
     def __init__(

--- a/python/aistore/sdk/etl/webserver/base_etl_server.py
+++ b/python/aistore/sdk/etl/webserver/base_etl_server.py
@@ -33,6 +33,10 @@ SYNC_DIRECT_PUT_TRANSIENT_ERRORS = (
 RETRY_BACKOFF_BASE = 2.0  # seconds; delay = base ** attempt
 RETRY_BACKOFF_MAX = 30.0  # seconds; upper bound on per-attempt delay
 
+# Drain-on-close chunk size for one-shot request-body readers
+# (used by `_FlaskRequestStreamReader` and `_RFileLimitedReader`).
+DRAIN_CHUNK_BYTES = 65536
+
 
 def _is_connection_refused(exc: requests.ConnectionError) -> bool:
     """

--- a/python/aistore/sdk/etl/webserver/flask_server.py
+++ b/python/aistore/sdk/etl/webserver/flask_server.py
@@ -4,8 +4,8 @@
 
 # pylint: disable=duplicate-code
 
+import io
 import time
-from io import BytesIO
 from urllib.parse import quote
 from typing import Iterator, Tuple
 
@@ -18,22 +18,59 @@ from aistore.sdk.etl.webserver.base_etl_server import (
     SYNC_DIRECT_PUT_TRANSIENT_ERRORS,
     RETRY_BACKOFF_BASE,
     RETRY_BACKOFF_MAX,
+    DRAIN_CHUNK_BYTES,
     _handle_direct_put_transient_error,
+    _compute_replayable_retries,
 )
 from aistore.sdk.etl.webserver.utils import (
     compose_etl_direct_put_url,
     parse_etl_pipeline,
+    _ResponseRawReader,
 )
 from aistore.sdk.errors import InvalidPipelineError, ETLDirectPutTransientError
 from aistore.sdk.const import (
     HEADER_NODE_URL,
     STATUS_OK,
     STATUS_BAD_GATEWAY,
+    STATUS_SERVICE_UNAVAILABLE,
     QPARAM_ETL_ARGS,
     QPARAM_ETL_FQN,
     HEADER_DIRECT_PUT_LENGTH,
+    HEADER_ETL_RETRY_REASON,
+    ETL_RETRY_REASON_DIRECT_PUT_TRANSIENT,
     STATUS_INTERNAL_SERVER_ERROR,
 )
+
+
+class _FlaskRequestStreamReader(io.RawIOBase):
+    """Wrap Werkzeug's request.stream for no-FQN PUT on the streaming path.
+
+    Werkzeug's LimitedStream inherits io.RawIOBase.close() without draining;
+    a transform that exits early would leave unread bytes on a keep-alive
+    connection. close() drains residual bytes in 64 KiB chunks (mirroring
+    _RFileLimitedReader.close() in HTTPMultiThreadedServer).
+    """
+
+    def __init__(self, stream) -> None:
+        self._stream = stream
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        return self._stream.read(size)
+
+    def close(self) -> None:
+        try:
+            while True:
+                try:
+                    chunk = self._stream.read(DRAIN_CHUNK_BYTES)
+                except (OSError, ValueError):
+                    break
+                if not chunk:
+                    break
+        finally:
+            super().close()
 
 
 class FlaskServer(ETLServer):
@@ -84,10 +121,30 @@ class FlaskServer(ETLServer):
                 404,
             )
         except ETLDirectPutTransientError as e:
+            # Contract with AIS: 503 + `Ais-Etl-Retry-Reason: direct-put-transient`
+            # fires only when the ETL bailed without trying locally (one-shot
+            # body — the streaming no-FQN PUT path). Exhausted-retry cases keep
+            # emitting 502: the ETL already tried and AIS retrying on top is
+            # just amplification.
+            if e.bail_without_local_retry:
+                self.logger.error(
+                    "Direct put bailed (one-shot body); AIS will retry: %s", e
+                )
+                return (
+                    jsonify({"error": f"Direct put bailed (one-shot body): {e}"}),
+                    STATUS_SERVICE_UNAVAILABLE,
+                    {HEADER_ETL_RETRY_REASON: ETL_RETRY_REASON_DIRECT_PUT_TRANSIENT},
+                )
             self.logger.error(
                 "Direct put failed after %d retries: %s", self.direct_put_retries, e
             )
             return jsonify({"error": str(e)}), STATUS_BAD_GATEWAY
+        except requests.HTTPError as e:
+            status = (
+                e.response.status_code if e.response is not None else STATUS_BAD_GATEWAY
+            )
+            self.logger.debug("Upstream GET returned %s", status)
+            return jsonify({"error": "Target request failed"}), status
         except requests.RequestException as e:
             self.logger.error("Request to AIS target failed: %s", str(e))
             return jsonify({"error": str(e)}), STATUS_BAD_GATEWAY
@@ -158,15 +215,8 @@ class FlaskServer(ETLServer):
             self.close_reader(reader)
             raise
 
-    def _get_stream_reader(self, path, buffered=False):
-        """Get a BinaryIO reader for the request source data.
-
-        Args:
-            path: The object path being processed.
-            buffered: If True, buffer the PUT body into a BytesIO so it can be
-                replayed on retry. If False (default), return request.stream for
-                true constant-memory streaming (no-pipeline path only).
-        """
+    def _get_stream_reader(self, path):
+        """Get a BinaryIO reader for the request source data."""
         fqn = request.args.get(QPARAM_ETL_FQN, "").strip()
         if fqn:
             # S2083: FQN is an internal AIS target path, not external user input.
@@ -179,15 +229,15 @@ class FlaskServer(ETLServer):
             resp = self.session.get(target_url, stream=True, timeout=None)
             try:
                 resp.raise_for_status()
-            except Exception:
+            except requests.HTTPError:
                 # stream=True pins the connection until we close or fully
                 # consume the body; release it immediately on error.
                 resp.close()
                 raise
-            return resp.raw
-        if buffered:
-            return BytesIO(request.get_data())
-        return request.stream
+            return _ResponseRawReader(resp)
+        # Request body is one-shot; local retries are skipped for this path
+        # (see _direct_put_stream_with_retry).
+        return _FlaskRequestStreamReader(request.stream)
 
     def _direct_put_with_retry(
         self,
@@ -225,14 +275,25 @@ class FlaskServer(ETLServer):
         """
         Streaming direct-put with exponential-backoff retry on transient errors.
 
-        Manages reader lifecycle internally, reopening the source on each retry
-        (mirrors FastAPIServer._direct_put_stream_with_retry). For PUT requests
-        without FQN, the body is buffered into a BytesIO via get_data() so retries
-        replay the same bytes.
+        Replayable sources (FQN-backed or GET) close and reopen the reader on
+        each retry. No-FQN PUT bodies are one-shot (request body consumed from
+        the socket); effective_retries is forced to 0 and a transient direct-put
+        error surfaces to AIS as a transform failure.
         """
-        reader = self._get_stream_reader(path, buffered=True)
+        fqn = request.args.get(QPARAM_ETL_FQN, "").strip()
+        is_get = request.method == "GET"
+        replayable, effective_retries = _compute_replayable_retries(
+            fqn, is_get, self.direct_put_retries
+        )
+        if not replayable and self.direct_put_retries:
+            self.logger.debug(
+                "no-FQN PUT: source not replayable; "
+                "local retries skipped; transient direct-put error "
+                "will surface as transform failure"
+            )
+        reader = self._get_stream_reader(path)
         try:
-            for attempt in range(self.direct_put_retries + 1):
+            for attempt in range(effective_retries + 1):
                 try:
                     return self._direct_put_stream(
                         direct_put_url,
@@ -241,19 +302,21 @@ class FlaskServer(ETLServer):
                         path,
                     )
                 except ETLDirectPutTransientError as exc:
-                    if attempt >= self.direct_put_retries:
+                    if attempt >= effective_retries:
+                        if not replayable:
+                            exc.bail_without_local_retry = True
                         raise
                     delay = min(RETRY_BACKOFF_BASE**attempt, RETRY_BACKOFF_MAX)
                     self.logger.warning(
                         "direct_put_stream attempt %d/%d failed, retrying in %.1fs: %s",
                         attempt + 1,
-                        self.direct_put_retries + 1,
+                        effective_retries + 1,
                         delay,
                         exc,
                         exc_info=True,
                     )
                     self.close_reader(reader)
-                    reader = self._get_stream_reader(path, buffered=True)
+                    reader = self._get_stream_reader(path)
                     time.sleep(delay)
         finally:
             self.close_reader(reader)

--- a/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
+++ b/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
@@ -19,6 +19,7 @@ from aistore.sdk.etl.webserver.base_etl_server import (
     SYNC_DIRECT_PUT_TRANSIENT_ERRORS,
     RETRY_BACKOFF_BASE,
     RETRY_BACKOFF_MAX,
+    DRAIN_CHUNK_BYTES,
     _handle_direct_put_transient_error,
     _compute_replayable_retries,
 )
@@ -85,7 +86,7 @@ class _RFileLimitedReader(io.RawIOBase):
         try:
             while self._remaining > 0:
                 try:
-                    chunk = self._rfile.read(min(self._remaining, 65536))
+                    chunk = self._rfile.read(min(self._remaining, DRAIN_CHUNK_BYTES))
                 except (OSError, ValueError):
                     break
                 if not chunk:

--- a/python/tests/unit/sdk/test_etl_webserver.py
+++ b/python/tests/unit/sdk/test_etl_webserver.py
@@ -49,7 +49,10 @@ from aistore.sdk.etl.webserver.http_multi_threaded_server import (
     HTTPMultiThreadedServer,
     _RFileLimitedReader,
 )
-from aistore.sdk.etl.webserver.flask_server import FlaskServer
+from aistore.sdk.etl.webserver.flask_server import (
+    FlaskServer,
+    _FlaskRequestStreamReader,
+)
 from aistore.sdk.etl.webserver.fastapi_server import FastAPIServer
 from aistore.sdk.etl.webserver.fastapi_streaming import _RequestStreamReader
 
@@ -1515,6 +1518,74 @@ class TestStreamingFlaskServer(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data, b"flask: " + input_data)
 
+    def test_streaming_put_bail_returns_503_with_reason(self):
+        """One-shot bail (bail_without_local_retry=True) returns 503 + retry-reason header."""
+        exc = ETLDirectPutTransientError(
+            "http://target/obj",
+            requests.ConnectionError("dropped"),
+            bail_without_local_retry=True,
+        )
+        headers = {HEADER_NODE_URL: "http://localhost:8080/ais/@/dst/test/obj"}
+        with patch.object(
+            self.etl_server, "_direct_put_stream_with_retry", side_effect=exc
+        ):
+            response = self.client.put("/test/obj", data=b"body", headers=headers)
+
+        self.assertEqual(response.status_code, STATUS_SERVICE_UNAVAILABLE)
+        self.assertEqual(
+            response.headers.get(HEADER_ETL_RETRY_REASON),
+            ETL_RETRY_REASON_DIRECT_PUT_TRANSIENT,
+        )
+
+    def test_streaming_put_exhausted_retries_returns_502(self):
+        """Replayable-exhausted (bail_without_local_retry=False) keeps emitting 502."""
+        exc = ETLDirectPutTransientError(
+            "http://target/obj", requests.ConnectionError("dropped")
+        )
+        headers = {HEADER_NODE_URL: "http://localhost:8080/ais/@/dst/test/obj"}
+        with patch.object(
+            self.etl_server, "_direct_put_stream_with_retry", side_effect=exc
+        ):
+            response = self.client.put("/test/obj", data=b"body", headers=headers)
+
+        self.assertEqual(response.status_code, STATUS_BAD_GATEWAY)
+        self.assertNotIn(HEADER_ETL_RETRY_REASON, response.headers)
+
+    def test_streaming_get_forwards_upstream_404(self):
+        """Upstream 404 is forwarded as-is, not collapsed to 502."""
+        mock_http_resp = MagicMock()
+        mock_http_resp.status_code = 404
+        err = requests.HTTPError(response=mock_http_resp)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = err
+        with patch.object(self.etl_server.session, "get", return_value=mock_resp):
+            response = self.client.get("/test/obj")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_streaming_get_forwards_upstream_500(self):
+        """Upstream 500 is forwarded as-is, not collapsed to 502."""
+        mock_http_resp = MagicMock()
+        mock_http_resp.status_code = 500
+        err = requests.HTTPError(response=mock_http_resp)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = err
+        with patch.object(self.etl_server.session, "get", return_value=mock_resp):
+            response = self.client.get("/test/obj")
+
+        self.assertEqual(response.status_code, 500)
+
+    def test_streaming_get_connection_error_returns_502(self):
+        """Network-level connection errors return 502 Bad Gateway."""
+        with patch.object(
+            self.etl_server.session,
+            "get",
+            side_effect=requests.ConnectionError("refused"),
+        ):
+            response = self.client.get("/test/obj")
+
+        self.assertEqual(response.status_code, STATUS_BAD_GATEWAY)
+
 
 class TestStreamingHTTPServer(unittest.TestCase):
     def setUp(self):
@@ -1695,6 +1766,96 @@ class TestHTTPStreamingLifecycle(unittest.TestCase):
         handler.do_GET()
 
         handler.server.etl_server.close_reader.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Flask streaming lifecycle: connection release and drain-on-close
+# ---------------------------------------------------------------------------
+
+
+class TestFlaskStreamingLifecycle(unittest.TestCase):
+    """Tests for response-lifecycle correctness in FlaskServer's streaming path."""
+
+    def setUp(self):
+        env = mock.patch.dict(os.environ, {"AIS_TARGET_URL": "http://localhost:8080"})
+        env.start()
+        self.addCleanup(env.stop)
+        self.server = DummyStreamingFlaskServer()
+        self.client = self.server.app.test_client()
+
+    def _make_ok_resp(self, body=b"data"):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.raw = io.BytesIO(body)
+        return mock_resp
+
+    def test_reader_close_releases_pool_connection(self):
+        """Closing the GET reader calls resp.close(), releasing the urllib3 pool slot."""
+        mock_resp = self._make_ok_resp()
+        with self.server.app.test_request_context("/test/obj", method="GET"):
+            with patch.object(self.server.session, "get", return_value=mock_resp):
+                reader = (
+                    self.server._get_stream_reader(  # pylint: disable=protected-access
+                        "test/obj"
+                    )
+                )
+        reader.close()
+        mock_resp.close.assert_called_once()
+
+    def test_raise_for_status_closes_resp(self):
+        """When raise_for_status fails, resp is closed before the exception propagates."""
+        mock_http_resp = MagicMock()
+        mock_http_resp.status_code = 404
+        err = requests.HTTPError(response=mock_http_resp)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = err
+        with self.server.app.test_request_context("/test/obj", method="GET"):
+            with patch.object(self.server.session, "get", return_value=mock_resp):
+                with self.assertRaises(requests.HTTPError):
+                    self.server._get_stream_reader(  # pylint: disable=protected-access
+                        "test/obj"
+                    )
+        mock_resp.close.assert_called_once()
+
+    def test_mid_stream_transform_error_closes_reader(self):
+        """Exception raised inside transform_stream still closes the GET reader."""
+        mock_resp = self._make_ok_resp()
+        with patch.object(self.server.session, "get", return_value=mock_resp):
+            with patch.object(
+                self.server,
+                "transform_stream",
+                side_effect=RuntimeError("transform crashed"),
+            ):
+                response = self.client.get("/test/obj")
+
+        mock_resp.close.assert_called_once()
+        self.assertEqual(response.status_code, 500)
+
+    def test_flask_request_stream_reader_close_drains_residual(self):
+        """_FlaskRequestStreamReader.close() drains all unread bytes from the stream."""
+        payload = b"ABCDEFGHIJ"  # 10 bytes
+        fake_stream = io.BytesIO(payload)
+        reader = _FlaskRequestStreamReader(fake_stream)
+        reader.read(4)  # consume 4; 6 remain
+        reader.close()
+        self.assertEqual(fake_stream.tell(), len(payload))
+        self.assertTrue(reader.closed)
+
+    def test_flask_request_stream_reader_close_swallows_oserror(self):
+        """close() swallows OSError during drain so it doesn't mask transform errors."""
+        fake_stream = MagicMock()
+        fake_stream.read.side_effect = OSError("socket reset")
+        reader = _FlaskRequestStreamReader(fake_stream)
+        reader.close()  # must not raise
+        self.assertTrue(reader.closed)
+
+    def test_flask_request_stream_reader_close_swallows_valueerror(self):
+        """close() swallows ValueError (closed stream) during drain."""
+        fake_stream = MagicMock()
+        fake_stream.read.side_effect = ValueError("I/O operation on closed file")
+        reader = _FlaskRequestStreamReader(fake_stream)
+        reader.close()  # must not raise
+        self.assertTrue(reader.closed)
 
 
 # ---------------------------------------------------------------------------
@@ -2216,10 +2377,18 @@ class TestFlaskStreamingDirectPutRetry(unittest.TestCase):
     def _make_reader(self, data=b"input"):
         return io.BytesIO(data)
 
-    def _call(self, path="test/obj"):
-        return self.server._direct_put_stream_with_retry(  # pylint: disable=protected-access
-            self._DIRECT_PUT_URL, path
-        )
+    def _call(self, path="test/obj", fqn="/fake/fqn.dat", method="PUT"):
+        """Run _direct_put_stream_with_retry inside a Flask request context.
+
+        Defaults to a FQN-backed PUT (replayable=True) so retry-logic tests
+        exercise the full retry budget without needing real file I/O (because
+        _get_stream_reader is mocked in every retry test).
+        """
+        qs = f"?{QPARAM_ETL_FQN}={fqn}" if fqn else ""
+        with self.server.app.test_request_context(f"/{path}{qs}", method=method):
+            return self.server._direct_put_stream_with_retry(  # pylint: disable=protected-access
+                self._DIRECT_PUT_URL, path
+            )
 
     def test_succeeds_on_first_attempt(self):
         """No retry when first attempt succeeds."""
@@ -2378,57 +2547,79 @@ class TestFlaskStreamingDirectPutRetry(unittest.TestCase):
         self.assertEqual(delays[1], min(2.0**1, 30.0))
         self.assertEqual(delays[2], min(2.0**2, 30.0))
 
-    def test_put_no_fqn_retry_sends_original_bytes(self):
-        """Regression: Flask streaming PUT without FQN replays original body on retry.
+    def test_no_fqn_put_skips_local_retries(self):
+        """Streaming no-FQN PUT is one-shot: no local retry; AIS retries the PUT.
 
-        Before the fix, _get_stream_reader returned request.stream which is exhausted
-        after the first read. A second call to _get_stream_reader would return an empty
-        stream, causing the retry to PUT zero bytes. After the fix, get_data() buffers
-        the body so each retry gets a fresh BytesIO over the original bytes.
+        request.stream cannot be replayed, so the retry loop must run exactly
+        once and surface ETLDirectPutTransientError on the first transient
+        failure (regardless of direct_put_retries). The exception must carry
+        bail_without_local_retry=True so the outer handler emits the
+        503 + Ais-Etl-Retry-Reason contract for AIS to retry.
         """
-        original_body = b"hello regression bytes"
-        bytes_read_by_transform = []
-
-        def spy_transform_stream(reader, _path, _etl_args):
-            data = reader.read()
-            bytes_read_by_transform.append(data)
-            yield data
-
-        call_count = 0
-
-        def mock_direct_put_stream(url, data_iter, *_a, **_kw):
-            nonlocal call_count
-            call_count += 1
-            # Consume the generator so transform_stream reads from reader.
-            b"".join(data_iter)
-            if call_count == 1:
-                raise ETLDirectPutTransientError(url, requests.ConnectionError())
-            return (204, b"", len(original_body))
-
-        self.server.direct_put_retries = 1
-        with self.server.app.test_request_context(
-            "/test/obj", method="PUT", data=original_body
+        self.server.direct_put_retries = 3
+        err = ETLDirectPutTransientError(
+            self._DIRECT_PUT_URL, requests.ConnectionError()
+        )
+        with patch.object(
+            self.server, "_get_stream_reader", return_value=self._make_reader()
         ):
             with patch.object(
-                self.server, "transform_stream", side_effect=spy_transform_stream
-            ):
-                with patch.object(
-                    self.server,
-                    "_direct_put_stream",
-                    side_effect=mock_direct_put_stream,
-                ):
-                    with patch("time.sleep"):
-                        self.server._direct_put_stream_with_retry(  # pylint: disable=protected-access
-                            self._DIRECT_PUT_URL, "/test/obj"
-                        )
+                self.server, "_direct_put_stream", side_effect=err
+            ) as mock_put:
+                with patch("time.sleep") as mock_sleep:
+                    with self.assertRaises(ETLDirectPutTransientError) as ctx:
+                        self._call(fqn="", method="PUT")
 
-        self.assertEqual(len(bytes_read_by_transform), 2, "expected 2 attempts")
-        self.assertEqual(bytes_read_by_transform[0], original_body)
-        self.assertEqual(
-            bytes_read_by_transform[1],
-            original_body,
-            "retry must send original bytes, not empty bytes",
+        self.assertEqual(mock_put.call_count, 1)
+        mock_sleep.assert_not_called()
+        self.assertTrue(ctx.exception.bail_without_local_retry)
+
+    def test_skip_retries_debug_log(self):
+        """Debug log fires when no-FQN PUT skips local retries."""
+        self.server.direct_put_retries = 3
+        err = ETLDirectPutTransientError(
+            self._DIRECT_PUT_URL, requests.ConnectionError()
         )
+        with patch.object(
+            self.server, "_get_stream_reader", return_value=self._make_reader()
+        ):
+            with patch.object(self.server, "_direct_put_stream", side_effect=err):
+                with patch("time.sleep"):
+                    with self.assertLogs(self.server.logger, level="DEBUG") as log_ctx:
+                        with self.assertRaises(ETLDirectPutTransientError):
+                            self._call(fqn="", method="PUT")
+
+        self.assertTrue(
+            any(
+                "not replayable" in msg or "local retries skipped" in msg
+                for msg in log_ctx.output
+            )
+        )
+
+    def test_replayable_exhausted_does_not_set_bail_flag(self):
+        """Replayable-exhausted PUTs raise with bail_without_local_retry=False.
+
+        AIS retrying after the ETL already exhausted its budget is just
+        amplification, so the outer handler must continue to emit 502.
+        """
+        self.server.direct_put_retries = 2
+        err = ETLDirectPutTransientError(
+            self._DIRECT_PUT_URL, requests.ConnectionError()
+        )
+        readers = [self._make_reader() for _ in range(3)]
+        reader_iter = iter(readers)
+        with patch.object(
+            self.server,
+            "_get_stream_reader",
+            side_effect=lambda *_, **__: next(reader_iter),
+        ):
+            with patch.object(self.server, "_direct_put_stream", side_effect=err):
+                with patch("time.sleep"):
+                    with self.assertRaises(ETLDirectPutTransientError) as ctx:
+                        # Default _call uses FQN → replayable; retries are exhausted.
+                        self._call()
+
+        self.assertFalse(ctx.exception.bail_without_local_retry)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #285, #289, and #293. `FlaskServer` was the last backend
that buffered the no-FQN `hpush` PUT body, leaked urllib3 connections
on `hpull` GET errors, collapsed upstream HTTP errors to 502, and did
not participate in the AIS 503 retry contract.

**Changes:**
- `_FlaskRequestStreamReader`: `io.RawIOBase` wrapper around
  `request.stream` so `transform_stream` reads chunk-by-chunk from the
  Werkzeug-bounded body; `close()` drains residual in 64 KiB chunks for
  keep-alive correctness on non-gunicorn deployments.
- `_get_stream_reader`: drop the buffered-body path; wrap upstream GET
  in `_ResponseRawReader` so `close()` returns the urllib3 socket to
  the pool; narrow `except Exception` to `except requests.HTTPError`.
- `_direct_put_stream_with_retry`: adopt `_compute_replayable_retries()`
  from `base_etl_server`; one-shot no-FQN PUT skips local retries and
  sets `bail_without_local_retry=True`.
- `_handle_request`: forward upstream HTTP statuses as-is via a
  `requests.HTTPError` branch before `RequestException` (also fixes
  the buffered `hpull` GET status path as a side-effect); branch
  `ETLDirectPutTransientError` on `bail_without_local_retry` for
  503-bail vs 502-exhausted.


**Tests:** new `TestFlaskStreamingLifecycle` (drain-on-close, GET pool
release, mid-stream error close, error swallowing); five outer-handler
tests in `TestStreamingFlaskServer` (503-bail, 502-exhausted, upstream
404/500 forwarding, connection-error 502); three new tests in
`TestFlaskStreamingDirectPutRetry` (no-FQN skip, debug log, bail-flag
positive/negative). Retired `test_put_no_fqn_retry_sends_original_bytes`
(tested the obsolete buffering path).
