### PR TITLE
fix: update broken local documentation links

### DIFF
--- a/bench/micro/disk/compare/README.md
+++ b/bench/micro/disk/compare/README.md
@@ -16,6 +16,6 @@ $ ./compare <disk1> ... <diskN> > /path/to/results.csv
 
 This continuously writes the benchmark data to `/path/to/results.csv`.
 
-During this time, load can be generated on the disks by using [`loadgen.sh`](/bench/disk/loadgen) in a different terminal. Note that the corresponding mount points corresponding to the disks need to be passed. This can be obtained with the `lsblk` command, the value under the `MOUNTPOINT` column is the corresponding mount point.
+During this time, load can be generated on the disks by using [`loadgen.sh`](/bench/micro/disk/loadgen/loadgen.sh) in a different terminal. Note that the corresponding mount points corresponding to the disks need to be passed. This can be obtained with the `lsblk` command, the value under the `MOUNTPOINT` column is the corresponding mount point.
 
 The benchmark can be stopped at any time by pressing `ctrl+c` in the controlling terminal.

--- a/bench/tools/aisloader-composer/README.md
+++ b/bench/tools/aisloader-composer/README.md
@@ -30,7 +30,7 @@ This directory contains scripts and ansible playbooks to benchmark an AIS cluste
 
 ### Optional
 
-1. To run disk benchmarks, uncomment the desired sections from the [disk_bench.sh](/bench/aisloader-composer/playbooks/scripts/disk_bench.sh) and run the `disk_bench.yaml` playbook with the `target_hosts` variable. This will trigger [fio](https://github.com/axboe/fio) benchmarks on the corresponding AIS targets.
+1. To run disk benchmarks, uncomment the desired sections from the [disk_bench.sh](/bench/tools/aisloader-composer/playbooks/scripts/disk_bench.sh) and run the `disk_bench.yaml` playbook with the `target_hosts` variable. This will trigger [fio](https://github.com/axboe/fio) benchmarks on the corresponding AIS targets.
 2. To view [grafana](https://github.com/grafana/grafana) dashboards with metrics sent by `aisloader` and `netdata`, use your browser to access `grafana_host` (see `grafana_host` argument in the scripts). Note that the default grafana port is `3000`. Then you can optionally import the included throughput dashboard in `grafana_dashboards`.
 3. To view individual host `netdata` dashboards, use your browser to access the host's IP at the `netdata` default port `19999`.
 

--- a/transport/README.md
+++ b/transport/README.md
@@ -148,7 +148,7 @@ On the wire, each transmitted object will have the layout:
 
 The size must be known upfront, which is the current limitation.
 
-A stream (the [Stream type](/transport/send.go)) carries a sequence of objects of arbitrary sizes and contents, and overall looks as follows:
+A stream (the [Stream type](/transport/api.go)) carries a sequence of objects of arbitrary sizes and contents, and overall looks as follows:
 
 > `object1 = (**[header1]**, **[data1]**)` `object2 = (**[header2]**, **[data2]**)`, etc.
 
@@ -266,4 +266,3 @@ For more examples, please see tests in the package directory.
 | Environment Variable | Description |
 |--- | --- |
 | `AIS_STREAM_DRY_RUN` | If enabled, read and immediately discard all read data (can be used to evaluate client-side throughput) |
-


### PR DESCRIPTION
Tiny docs papercut, nothing fancy. Three README links pointed at paths that no longer exist, so clicking them on GitHub lands in 404-land.

Repro:
- open `transport/README.md`, `bench/micro/disk/compare/README.md`, or `bench/tools/aisloader-composer/README.md`
- click the old local links, or run a local Path.exists check
- old targets are missing: `/transport/send.go`, `/bench/disk/loadgen`, `/bench/aisloader-composer/playbooks/scripts/disk_bench.sh`

Fix:
- point each link at the file that exists now.

Checks:
- local link checker for touched files
- `git diff --check`
- `go test ./cmn/cos ./cmn/archive ./cmn/jsp ./fs/...`
- `cd python && python -m pytest -q tests/unit/sdk/test_utils.py`