### PR TITLE
fix: rename NewErrInvalidaMountpath -> NewErrInvalidMountpath (typo)

### DIFF
--- a/cmn/config.go
+++ b/cmn/config.go
@@ -2449,13 +2449,13 @@ func ValidateMpath(mpath string) (string, error) {
 	cleanMpath := filepath.Clean(mpath)
 
 	if cleanMpath[0] != filepath.Separator {
-		return mpath, NewErrInvalidaMountpath(mpath, "mountpath must be an absolute path")
+		return mpath, NewErrInvalidMountpath(mpath, "mountpath must be an absolute path")
 	}
 	if cleanMpath == cos.PathSeparator {
-		return "", NewErrInvalidaMountpath(mpath, "root directory is not a valid mountpath")
+		return "", NewErrInvalidMountpath(mpath, "root directory is not a valid mountpath")
 	}
 	if len(cleanMpath) > maxLenMountpath {
-		return "", NewErrInvalidaMountpath(mpath, "mountpath length cannot exceed "+strconv.Itoa(maxLenMountpath))
+		return "", NewErrInvalidMountpath(mpath, "mountpath length cannot exceed "+strconv.Itoa(maxLenMountpath))
 	}
 	return cleanMpath, nil
 }

--- a/cmn/err.go
+++ b/cmn/err.go
@@ -613,7 +613,7 @@ func (e *ErrInvalidMountpath) Error() string {
 	return "invalid mountpath [" + e.mpath + "]; " + e.cause
 }
 
-func NewErrInvalidaMountpath(mpath, cause string) *ErrInvalidMountpath {
+func NewErrInvalidMountpath(mpath, cause string) *ErrInvalidMountpath {
 	return &ErrInvalidMountpath{mpath: mpath, cause: cause}
 }
 


### PR DESCRIPTION
`NewErrInvalidaMountpath` has a stray `a` that snuck in between `Invalid` and `Mountpath`. The error type itself is `ErrInvalidMountpath` (correct), but the constructor got the extra char. Bit embarrassing tbh.

**Files changed:** `cmn/err.go` (definition) + `cmn/config.go` (3 call sites). All callers are within the `cmn` package so no breakage outside.

**To reproduce:**
```go
// grep for the old name - it compiles fine but looks wrong
grep NewErrInvalidaMountpath cmn/err.go
// => func NewErrInvalidaMountpath(mpath, cause string) *ErrInvalidMountpath
```

The struct is `ErrInvalidMountpath`, the constructor should match.

**Fix:** rename the func + update 3 call sites in `ValidateMpath`. Zero behavior change, just fixing the name.
