### PR TITLE
fix: correct xact README snapshot link

### DIFF
--- a/xact/README.md
+++ b/xact/README.md
@@ -111,7 +111,7 @@ report to IC.
 
 ## Snapshots
 
-A snapshot, or [`core.Snap`](core/xaction.go), is a local description of an xaction instance.
+A snapshot, or [`core.Snap`](../core/xaction.go), is a local description of an xaction instance.
 
 Snapshots are the general-purpose status representation for xactions registered
 locally. A snapshot can include common fields such as kind, ID, bucket, start


### PR DESCRIPTION
Tiny docs papercut.

`xact/README.md` links `core/xaction.go` from inside `xact/`, so GitHub resolves it to `xact/core/xaction.go` and the click goes to a 404.

Fix is just switching that link to `../core/xaction.go`.

Repro:
1. Open `xact/README.md` on GitHub.
2. Click `core.Snap`.
3. Hit 404

Local repro:
1. `cd xact`
2. `test -e core/xaction.go || echo broken`
3. `test -e ../core/xaction.go && echo fixed-target`
