### PR TITLE
etl: forward etl_args across pipeline stages

### DIFF
--- a/ext/etl/webserver/webserver.go
+++ b/ext/etl/webserver/webserver.go
@@ -169,7 +169,8 @@ func (base *etlServerBase) getHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (base *etlServerBase) handleRequest(objReader io.ReadCloser, w http.ResponseWriter, r *http.Request) {
-	transformedReader, size, err := base.Transform(objReader, r.URL.Path, r.URL.Query().Get(apc.QparamETLTransformArgs))
+	etlArgs := r.URL.Query().Get(apc.QparamETLTransformArgs)
+	transformedReader, size, err := base.Transform(objReader, r.URL.Path, etlArgs)
 	if err != nil {
 		cmn.WriteErr(w, r, fmt.Errorf("[%s] %w", "failed to transform", err))
 		return
@@ -177,7 +178,7 @@ func (base *etlServerBase) handleRequest(objReader io.ReadCloser, w http.Respons
 	objReader.Close() // objReader is supposed to be fully consumed by the custom transform function - safe to close at this point
 
 	if directPutURL := r.Header.Get(apc.HdrNodeURL); directPutURL != "" {
-		base.handleDirectPut(w, transformedReader, size, r.URL.Path, directPutURL)
+		base.handleDirectPut(w, transformedReader, size, r.URL.Path, directPutURL, etlArgs)
 		return
 	}
 
@@ -251,10 +252,10 @@ func (base *etlServerBase) handleWebsocketMessage(conn *websocket.Conn, ctrl etl
 	}
 	defer reader.Close()
 
-	return base.handleWebsocketPipeline(conn, transformed, size, ctrl.Path, ctrl.Pipeline)
+	return base.handleWebsocketPipeline(conn, transformed, size, ctrl.Path, ctrl.Pipeline, ctrl.Targs)
 }
 
-func (base *etlServerBase) handleWebsocketPipeline(conn *websocket.Conn, transformed io.ReadCloser, size int64, objPath, pipeline string) (err error) {
+func (base *etlServerBase) handleWebsocketPipeline(conn *websocket.Conn, transformed io.ReadCloser, size int64, objPath, pipeline, etlArgs string) (err error) {
 	// No pipeline, send transformed data
 	if pipeline == "" {
 		writer, _ := conn.NextWriter(websocket.BinaryMessage)
@@ -266,7 +267,7 @@ func (base *etlServerBase) handleWebsocketPipeline(conn *websocket.Conn, transfo
 	}
 
 	firstURL, remainingPipeline := parsePipelineURL(pipeline)
-	dresp, err := base.directPut(firstURL, transformed, size, objPath, remainingPipeline)
+	dresp, err := base.directPut(firstURL, transformed, size, objPath, remainingPipeline, etlArgs)
 	if err != nil {
 		writer, _ := conn.NextWriter(websocket.TextMessage)
 		writer.Write([]byte(err.Error()))
@@ -296,9 +297,9 @@ func (base *etlServerBase) handleWebsocketPipeline(conn *websocket.Conn, transfo
 	return nil
 }
 
-func (base *etlServerBase) handleDirectPut(w http.ResponseWriter, transformedReader io.ReadCloser, size int64, objPath, directPutURL string) {
+func (base *etlServerBase) handleDirectPut(w http.ResponseWriter, transformedReader io.ReadCloser, size int64, objPath, directPutURL, etlArgs string) {
 	firstURL, remainingPipeline := parsePipelineURL(directPutURL)
-	dresp, err := base.directPut(firstURL, transformedReader, size, objPath, remainingPipeline)
+	dresp, err := base.directPut(firstURL, transformedReader, size, objPath, remainingPipeline, etlArgs)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -385,7 +386,7 @@ func (*etlServerBase) getFQNReader(urlPath string) (io.ReadCloser, error) {
 	return os.Open(fqn)
 }
 
-func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size int64, objPath, remainingPipelineURL string) (*directPutResponse, error) {
+func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size int64, objPath, remainingPipelineURL, etlArgs string) (*directPutResponse, error) {
 	direct, err := url.Parse(directPutURL)
 	if err != nil {
 		r.Close()
@@ -399,7 +400,18 @@ func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size 
 
 	finalURL := *host
 	finalURL.Host = direct.Host
-	finalURL.RawQuery = direct.RawQuery
+	// Carry etl_args to the next pipeline stage; the receiving ETL server reads it
+	// from the incoming query (see handleRequest). Merge so the destination target's
+	// xid/owt query params (final hop) are preserved. Encode() re-serializes the
+	// merged params and percent-encodes etlArgs, which arrives decoded and may
+	// contain characters that are not safe in a raw query string (e.g. JSON braces).
+	if etlArgs != "" {
+		q := direct.Query()
+		q.Set(apc.QparamETLTransformArgs, etlArgs)
+		finalURL.RawQuery = q.Encode()
+	} else {
+		finalURL.RawQuery = direct.RawQuery
+	}
 	if direct.Path != "" {
 		finalURL.Path = cos.JoinPath(host.Path, direct.Path)
 	} else {

--- a/ext/etl/webserver/webserver_internal_test.go
+++ b/ext/etl/webserver/webserver_internal_test.go
@@ -196,6 +196,75 @@ func TestETLServerPutHandler(t *testing.T) {
 	})
 }
 
+func TestETLServerDirectPutForwardsArgs(t *testing.T) {
+	var (
+		secretPrefix = "/v1/_object/some_secret"
+		host         = "http://0.0.0.0"
+		port         = "8080"
+
+		svr = &etlServerBase{
+			aisTargetURL: host + secretPrefix,
+			endpoint:     host + ":" + port,
+			client:       &http.Client{},
+			ETLServer:    &EchoServer{},
+		}
+
+		directPutPath = "ais@#test/obj"
+		etlArgs       = `{"format":"jpeg"}`
+	)
+
+	t.Run("present", func(t *testing.T) {
+		var gotArgs string
+		directPutTargetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotArgs = r.URL.Query().Get(apc.QparamETLTransformArgs)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer directPutTargetServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+			q       = req.URL.Query()
+		)
+		q.Set(apc.QparamETLTransformArgs, etlArgs)
+		req.URL.RawQuery = q.Encode()
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(directPutTargetServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		tassert.Fatalf(t, http.StatusNoContent == resp.StatusCode, "expected status code 204, got %d", resp.StatusCode)
+		tassert.Fatalf(t, gotArgs == etlArgs, "expected forwarded etl_args %q, got %q", etlArgs, gotArgs)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		var argsExists bool
+		directPutTargetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, argsExists = r.URL.Query()[apc.QparamETLTransformArgs]
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer directPutTargetServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+		)
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(directPutTargetServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		tassert.Fatalf(t, http.StatusNoContent == resp.StatusCode, "expected status code 204, got %d", resp.StatusCode)
+		tassert.Fatalf(t, !argsExists, "expected no etl_args query param when none provided")
+	})
+}
+
 func TestEchoServerGetHandler(t *testing.T) {
 	var (
 		secretPrefix = "/v1/_object/some_secret"

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -23,6 +23,12 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
   pre-convergence behavior). `wait_for_idle` and `wait_single_node` remain
   available as explicit overrides.
 
+### Fixed
+
+- ETL webservers now forward
+  `etl_args` to the next stage on direct-put pipeline hops. Previously only the
+  first pipeline stage received `etl_args`; stages 2..N saw an empty value.
+
 ## [1.25.0] - 2026-05-20
 
 ### Added

--- a/python/aistore/sdk/etl/webserver/fastapi_server.py
+++ b/python/aistore/sdk/etl/webserver/fastapi_server.py
@@ -270,7 +270,7 @@ class FastAPIServer(ETLServer):
             if first_url:
                 status_code, transformed, direct_put_length = (
                     await self._direct_put_with_retry(
-                        first_url, transformed, remaining_pipeline, path
+                        first_url, transformed, remaining_pipeline, path, etl_args
                     )
                 )
                 self.logger.debug("status_code: %r", status_code)
@@ -426,6 +426,7 @@ class FastAPIServer(ETLServer):
                         self.transform_stream(reader, path, etl_args),
                         remaining,
                         path,
+                        etl_args,
                     )
                 except ETLDirectPutTransientError as exc:
                     if attempt >= effective_retries:
@@ -450,12 +451,13 @@ class FastAPIServer(ETLServer):
         finally:
             self.close_reader(reader)
 
-    async def _direct_put_stream(
+    async def _direct_put_stream(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data_iter: Iterator[bytes],
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """
         Stream transformed output directly to the next pipeline stage.
@@ -467,7 +469,9 @@ class FastAPIServer(ETLServer):
               - length: bytes sent to the destination, from CountingIterator.
         """
         try:
-            url = compose_etl_direct_put_url(direct_put_url, self.host_target, path)
+            url = compose_etl_direct_put_url(
+                direct_put_url, self.host_target, path, etl_args
+            )
             headers = {}
             if remaining_pipeline:
                 headers[HEADER_NODE_URL] = remaining_pipeline
@@ -520,12 +524,13 @@ class FastAPIServer(ETLServer):
         for i in range(0, len(data), chunk_size):
             yield data[i : i + chunk_size]
 
-    async def _direct_put_with_retry(
+    async def _direct_put_with_retry(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data: bytes,
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """
         Buffered direct-put with exponential-backoff retry on transient network errors.
@@ -538,7 +543,7 @@ class FastAPIServer(ETLServer):
         for attempt in range(self.direct_put_retries + 1):
             try:
                 return await self._direct_put(
-                    direct_put_url, data, remaining_pipeline, path
+                    direct_put_url, data, remaining_pipeline, path, etl_args
                 )
             except ETLDirectPutTransientError as exc:
                 if attempt >= self.direct_put_retries:
@@ -553,12 +558,13 @@ class FastAPIServer(ETLServer):
                 )
                 await asyncio.sleep(delay)
 
-    async def _direct_put(
+    async def _direct_put(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data: bytes,
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """
         Sends the transformed object directly to the specified AIS node (`direct_put_url`),
@@ -570,6 +576,7 @@ class FastAPIServer(ETLServer):
             data: The transformed data to send
             remaining_pipeline: Comma-separated remaining pipeline stages to pass as header
             path: The path of the object.
+            etl_args: Per-request transform arguments to forward to the next stage.
         Returns:
             status code, transformed data, length of the transformed data (if any)
         Raises:
@@ -577,11 +584,12 @@ class FastAPIServer(ETLServer):
                 so the caller can retry without re-fetching data.
         """
         try:
-            url = compose_etl_direct_put_url(direct_put_url, self.host_target, path)
+            url = compose_etl_direct_put_url(
+                direct_put_url, self.host_target, path, etl_args
+            )
             headers = {HEADER_CONTENT_LENGTH: str(len(data))}
             if remaining_pipeline:
                 headers[HEADER_NODE_URL] = remaining_pipeline
-            # TODO: add etl_args to qparams if present
 
             resp = await self.client.put(
                 url, content=self._iter_chunks(data, self.chunk_size), headers=headers
@@ -621,7 +629,7 @@ class FastAPIServer(ETLServer):
 
         fqn = ctrl_msg.get(ETL_WS_FQN)
         path = ctrl_msg.get(ETL_WS_PATH)
-        etl_args = ctrl_msg.get(QPARAM_ETL_ARGS)
+        etl_args = ctrl_msg.get(QPARAM_ETL_ARGS, "").strip()
 
         if fqn and self.direct_fqn:
             source = self.sanitize_fqn(fqn)
@@ -642,7 +650,7 @@ class FastAPIServer(ETLServer):
                 if first_url:
                     status_code, transformed, direct_put_length = (
                         await self._direct_put_with_retry(
-                            first_url, transformed, remaining_pipeline, path
+                            first_url, transformed, remaining_pipeline, path, etl_args
                         )
                     )
                     if status_code == STATUS_OK:

--- a/python/aistore/sdk/etl/webserver/flask_server.py
+++ b/python/aistore/sdk/etl/webserver/flask_server.py
@@ -159,6 +159,7 @@ class FlaskServer(ETLServer):
         else:
             transformed = self._handle_put(path)
 
+        etl_args = request.args.get(QPARAM_ETL_ARGS, "").strip()
         pipeline_header = request.headers.get(HEADER_NODE_URL)
         self.logger.debug("pipeline_header: %r", pipeline_header)
         if pipeline_header:
@@ -166,7 +167,7 @@ class FlaskServer(ETLServer):
             if first_url:
                 status_code, transformed, direct_put_length = (
                     self._direct_put_with_retry(
-                        first_url, transformed, remaining_pipeline, path
+                        first_url, transformed, remaining_pipeline, path, etl_args
                     )
                 )
                 return Response(
@@ -239,17 +240,20 @@ class FlaskServer(ETLServer):
         # (see _direct_put_stream_with_retry).
         return _FlaskRequestStreamReader(request.stream)
 
-    def _direct_put_with_retry(
+    def _direct_put_with_retry(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data: bytes,
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """Buffered direct-put with exponential-backoff retry on transient errors."""
         for attempt in range(self.direct_put_retries + 1):
             try:
-                return self._direct_put(direct_put_url, data, remaining_pipeline, path)
+                return self._direct_put(
+                    direct_put_url, data, remaining_pipeline, path, etl_args
+                )
             except ETLDirectPutTransientError as exc:
                 if attempt >= self.direct_put_retries:
                     raise
@@ -300,6 +304,7 @@ class FlaskServer(ETLServer):
                         self.transform_stream(reader, path, etl_args),
                         remaining_pipeline,
                         path,
+                        etl_args,
                     )
                 except ETLDirectPutTransientError as exc:
                     if attempt >= effective_retries:
@@ -322,16 +327,19 @@ class FlaskServer(ETLServer):
             self.close_reader(reader)
         raise AssertionError("unreachable: loop always returns or raises")
 
-    def _direct_put_stream(
+    def _direct_put_stream(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data_iter: Iterator[bytes],
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """Stream transformed output directly to the next pipeline stage."""
         try:
-            url = compose_etl_direct_put_url(direct_put_url, self.host_target, path)
+            url = compose_etl_direct_put_url(
+                direct_put_url, self.host_target, path, etl_args
+            )
             headers = {}
             if remaining_pipeline:
                 headers[HEADER_NODE_URL] = remaining_pipeline
@@ -389,12 +397,13 @@ class FlaskServer(ETLServer):
         with open(safe_path, "rb") as f:
             return f.read()
 
-    def _direct_put(
+    def _direct_put(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         direct_put_url: str,
         data: bytes,
         remaining_pipeline: str = "",
         path: str = "",
+        etl_args: str = "",
     ) -> Tuple[int, bytes, int]:
         """
         Sends the transformed object directly to the specified AIS node (`direct_put_url`),
@@ -406,11 +415,14 @@ class FlaskServer(ETLServer):
             data: The transformed data to send
             remaining_pipeline: Comma-separated remaining pipeline stages to pass as header
             path: The path of the object.
+            etl_args: Per-request transform arguments to forward to the next stage.
         Returns:
             status code, transformed data, length of the transformed data (if any)
         """
         try:
-            url = compose_etl_direct_put_url(direct_put_url, self.host_target, path)
+            url = compose_etl_direct_put_url(
+                direct_put_url, self.host_target, path, etl_args
+            )
             headers = {}
             if remaining_pipeline:
                 headers[HEADER_NODE_URL] = remaining_pipeline

--- a/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
+++ b/python/aistore/sdk/etl/webserver/http_multi_threaded_server.py
@@ -165,12 +165,13 @@ class HTTPMultiThreadedServer(ETLServer):
             self.end_headers()
             self.wfile.write(body)
 
-        def _direct_put(
+        def _direct_put(  # pylint: disable=too-many-arguments,too-many-positional-arguments
             self,
             direct_put_url: str,
             data: bytes,
             remaining_pipeline: str = "",
             path: str = "",
+            etl_args: str = "",
         ) -> Tuple[int, bytes, int]:
             """
             Sends the transformed object directly to the specified AIS node (`direct_put_url`),
@@ -182,12 +183,13 @@ class HTTPMultiThreadedServer(ETLServer):
                 data: The transformed data to send
                 remaining_pipeline: Comma-separated remaining pipeline stages to pass as header
                 path: The path of the object.
+                etl_args: Per-request transform arguments to forward to the next stage.
             Returns:
                 status code of the direct put request, transformed data, length of the transformed data (if any)
             """
             try:
                 url = compose_etl_direct_put_url(
-                    direct_put_url, self.server.etl_server.host_target, path
+                    direct_put_url, self.server.etl_server.host_target, path, etl_args
                 )
                 headers = {}
                 if remaining_pipeline:
@@ -240,19 +242,20 @@ class HTTPMultiThreadedServer(ETLServer):
             content_length = int(self.headers.get(HEADER_CONTENT_LENGTH, 0))
             return _RFileLimitedReader(self.rfile, content_length)
 
-        def _direct_put_with_retry(
+        def _direct_put_with_retry(  # pylint: disable=too-many-arguments,too-many-positional-arguments
             self,
             direct_put_url: str,
             data: bytes,
             remaining_pipeline: str = "",
             path: str = "",
+            etl_args: str = "",
         ) -> Tuple[int, bytes, int]:
             """Buffered direct-put with exponential-backoff retry on transient errors."""
             etl = self.server.etl_server
             for attempt in range(etl.direct_put_retries + 1):
                 try:
                     return self._direct_put(
-                        direct_put_url, data, remaining_pipeline, path
+                        direct_put_url, data, remaining_pipeline, path, etl_args
                     )
                 except ETLDirectPutTransientError as exc:
                     if attempt >= etl.direct_put_retries:
@@ -299,6 +302,7 @@ class HTTPMultiThreadedServer(ETLServer):
                             etl.transform_stream(reader, raw_path, etl_args),
                             remaining_pipeline,
                             raw_path,
+                            etl_args,
                         )
                     except ETLDirectPutTransientError as exc:
                         if attempt >= effective_retries:
@@ -341,17 +345,18 @@ class HTTPMultiThreadedServer(ETLServer):
                     self.wfile.write(chunk)
             self.wfile.flush()
 
-        def _direct_put_stream(
+        def _direct_put_stream(  # pylint: disable=too-many-arguments,too-many-positional-arguments
             self,
             direct_put_url: str,
             data_iter: Iterator[bytes],
             remaining_pipeline: str = "",
             path: str = "",
+            etl_args: str = "",
         ) -> Tuple[int, bytes, int]:
             """Stream transformed output directly to the next pipeline stage."""
             try:
                 url = compose_etl_direct_put_url(
-                    direct_put_url, self.server.etl_server.host_target, path
+                    direct_put_url, self.server.etl_server.host_target, path, etl_args
                 )
                 headers = {}
                 if remaining_pipeline:
@@ -381,7 +386,9 @@ class HTTPMultiThreadedServer(ETLServer):
                 )
                 return STATUS_INTERNAL_SERVER_ERROR, str(e).encode(), 0
 
-        def _send_with_pipeline(self, transformed: bytes, path: str):
+        def _send_with_pipeline(
+            self, transformed: bytes, path: str, etl_args: str = ""
+        ):
             """
             Forward transformed data to the next ETL stage if a pipeline header exists;
             otherwise, respond directly with the transformed data.
@@ -389,6 +396,7 @@ class HTTPMultiThreadedServer(ETLServer):
             Args:
                 transformed (bytes): The transformed data to be sent.
                 path (str): The path of the object.
+                etl_args (str): Per-request transform arguments to forward to the next stage.
             """
             pipeline_header = self.headers.get(HEADER_NODE_URL)
             if pipeline_header:
@@ -396,7 +404,7 @@ class HTTPMultiThreadedServer(ETLServer):
                 if first_url:
                     status_code, transformed, direct_put_length = (
                         self._direct_put_with_retry(
-                            first_url, transformed, remaining_pipeline, path
+                            first_url, transformed, remaining_pipeline, path, etl_args
                         )
                     )
                     self._set_headers(
@@ -506,7 +514,7 @@ class HTTPMultiThreadedServer(ETLServer):
                     source, raw_path, etl_args
                 )
 
-                self._send_with_pipeline(transformed, raw_path)
+                self._send_with_pipeline(transformed, raw_path, etl_args)
 
             except InvalidPipelineError as e:
                 self.server.etl_server.logger.error(
@@ -585,7 +593,7 @@ class HTTPMultiThreadedServer(ETLServer):
                     source, raw_path, etl_args
                 )
 
-                self._send_with_pipeline(transformed, raw_path)
+                self._send_with_pipeline(transformed, raw_path, etl_args)
 
             except InvalidPipelineError as e:
                 self.server.etl_server.logger.error(

--- a/python/aistore/sdk/etl/webserver/utils.py
+++ b/python/aistore/sdk/etl/webserver/utils.py
@@ -4,12 +4,12 @@
 
 import base64
 from typing import Type, Tuple
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
 import cloudpickle
 import requests
 from aistore.sdk.etl.webserver.base_etl_server import ETLServer
-from aistore.sdk.const import UTF_ENCODING
+from aistore.sdk.const import UTF_ENCODING, QPARAM_ETL_ARGS
 from aistore.sdk.errors import InvalidPipelineError
 
 
@@ -59,7 +59,7 @@ def serialize_class(cls: Type[ETLServer], encoding: str = UTF_ENCODING) -> str:
 
 
 def compose_etl_direct_put_url(
-    direct_put_url: str, host_target: str, obj_path: str
+    direct_put_url: str, host_target: str, obj_path: str, etl_args: str = ""
 ) -> str:
     """
     Compose the final direct PUT URL by combining components from multiple URLs.
@@ -73,6 +73,9 @@ def compose_etl_direct_put_url(
         direct_put_url (str): Destination node's direct PUT URL, possibly with path/query.
         host_target (str): Base AIS target URL used for scheme and base path.
         obj_path (str): Path of the object to PUT.
+        etl_args (str): Per-request transform arguments to forward to the next
+            pipeline stage (the receiving ETL server reads them from the incoming
+            query). Empty string forwards nothing.
     Returns:
         str: Complete direct PUT URL targeting the correct AIS node.
     """
@@ -86,11 +89,24 @@ def compose_etl_direct_put_url(
         # Case 1: pipeline stage → append object path
         final_path = obj_path
 
+    # Keep xid/stats query params from the destination, then replace any existing
+    # etl_args so downstream stages receive the same per-request args without
+    # producing duplicates (mirrors Go's q.Set semantics).
+    query = direct.query
+    if etl_args:
+        query_pairs = [
+            (k, v)
+            for k, v in parse_qsl(direct.query, keep_blank_values=True)
+            if k != QPARAM_ETL_ARGS
+        ]
+        query_pairs.append((QPARAM_ETL_ARGS, etl_args))
+        query = urlencode(query_pairs)
+
     return urlunparse(
         host._replace(
             netloc=direct.netloc,
             path=final_path,
-            query=direct.query,  # keep xid or stats query params
+            query=query,
         )
     )
 

--- a/python/tests/unit/sdk/test_etl_webserver.py
+++ b/python/tests/unit/sdk/test_etl_webserver.py
@@ -4,7 +4,7 @@ import os
 import sys
 import io
 import unittest
-from urllib.parse import quote as url_quote
+from urllib.parse import quote as url_quote, urlparse, parse_qs
 from unittest import mock
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -36,6 +36,7 @@ from aistore.sdk.const import (
     HEADER_ETL_RETRY_REASON,
     ETL_RETRY_REASON_DIRECT_PUT_TRANSIENT,
     QPARAM_ETL_FQN,
+    QPARAM_ETL_ARGS,
     AIS_DIRECT_PUT_RETRIES,
     STATUS_BAD_GATEWAY,
     STATUS_SERVICE_UNAVAILABLE,
@@ -55,6 +56,7 @@ from aistore.sdk.etl.webserver.flask_server import (
 )
 from aistore.sdk.etl.webserver.fastapi_server import FastAPIServer
 from aistore.sdk.etl.webserver.fastapi_streaming import _RequestStreamReader
+from aistore.sdk.etl.webserver.utils import compose_etl_direct_put_url
 
 
 class DummyHTTPETLServer(HTTPMultiThreadedServer):
@@ -3151,3 +3153,155 @@ class TestHTTPConnectionRefusedGuard(unittest.TestCase):
         )
         with self.assertRaises(ETLDirectPutTransientError):
             self._put()
+
+
+class TestComposeETLDirectPutURL(unittest.TestCase):
+    """compose_etl_direct_put_url forwards etl_args while preserving existing query params."""
+
+    host = "http://localhost:8080/v1/etl/_object/etl-name/secret"
+
+    def test_pipeline_stage_appends_etl_args(self):
+        """Bare next-stage URL (no query) gets etl_args added."""
+        url = compose_etl_direct_put_url(
+            "http://stage2:8080", self.host, "bucket/obj", "jpeg"
+        )
+        self.assertEqual(parse_qs(urlparse(url).query), {QPARAM_ETL_ARGS: ["jpeg"]})
+
+    def test_offline_preserves_existing_query_and_appends_args(self):
+        """Destination-target query params (xid/owt) are preserved and etl_args added."""
+        dst = "http://tgt:8080/some/path?uuid=xyz&owt=5"
+        url = compose_etl_direct_put_url(dst, self.host, "bucket/obj", "jpeg")
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query["uuid"], ["xyz"])
+        self.assertEqual(query["owt"], ["5"])
+        self.assertEqual(query[QPARAM_ETL_ARGS], ["jpeg"])
+
+    def test_no_etl_args_leaves_query_unchanged(self):
+        """Empty etl_args forwards nothing and leaves the destination query as-is."""
+        dst = "http://tgt:8080/some/path?uuid=xyz"
+        url = compose_etl_direct_put_url(dst, self.host, "bucket/obj", "")
+        self.assertEqual(urlparse(url).query, "uuid=xyz")
+
+    def test_etl_args_special_chars_round_trip(self):
+        """JSON-style etl_args survive URL-encoding and decode back intact."""
+        args = '{"resize":"256x256"}'
+        url = compose_etl_direct_put_url("http://stage2:8080", self.host, "b/o", args)
+        self.assertEqual(parse_qs(urlparse(url).query)[QPARAM_ETL_ARGS], [args])
+
+    def test_existing_etl_args_replaced(self):
+        """An etl_args already in the destination query is replaced, not duplicated."""
+        dst = "http://tgt:8080/some/path?uuid=xyz&etl_args=old"
+        url = compose_etl_direct_put_url(dst, self.host, "bucket/obj", "jpeg")
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query["uuid"], ["xyz"])
+        self.assertEqual(query[QPARAM_ETL_ARGS], ["jpeg"])
+
+
+class TestETLArgsPipelineForwarding(unittest.TestCase):
+    """Each server forwards the incoming etl_args onto the direct-put hop so that
+    downstream pipeline stages receive the same per-request args (previously only
+    the first stage did)."""
+
+    def setUp(self):
+        env = mock.patch.dict(
+            os.environ,
+            {"AIS_TARGET_URL": "http://localhost:8080", "DIRECT_PUT": "true"},
+        )
+        env.start()
+        self.addCleanup(env.stop)
+
+    def test_http_buffered_forwards_etl_args(self):
+        """HTTPMultiThreadedServer forwards etl_args on the buffered direct-put hop."""
+        handler = DummyRequestHandler()
+        handler.path = "/test/object?etl_args=jpeg"
+        handler.headers = {HEADER_NODE_URL: "http://some-target/put/object"}
+
+        mock_put_resp = MagicMock(status_code=200, content=b"")
+        handler.server.etl_server.client_put.return_value = mock_put_resp
+
+        handler.do_PUT()
+
+        called_url = handler.server.etl_server.client_put.call_args.args[0]
+        self.assertEqual(
+            parse_qs(urlparse(called_url).query)[QPARAM_ETL_ARGS], ["jpeg"]
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 9), "requires Python 3.9 or higher")
+    def test_fastapi_buffered_forwards_etl_args(self):
+        """FastAPIServer forwards etl_args on the buffered direct-put hop."""
+        server = DummyFastAPIServer()
+        client = TestClient(server.app)
+        server.client = AsyncMock()
+        server.client.put.return_value = AsyncMock(status_code=200, content=b"")
+
+        headers = {HEADER_NODE_URL: "http://localhost:8080/ais/@/etl_dst/test/object"}
+        response = client.put(
+            "/test/object?etl_args=jpeg", content=b"input data", headers=headers
+        )
+
+        self.assertEqual(response.status_code, 204)
+        called_url = server.client.put.call_args.args[0]
+        self.assertEqual(
+            parse_qs(urlparse(called_url).query)[QPARAM_ETL_ARGS], ["jpeg"]
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 9), "requires Python 3.9 or higher")
+    def test_fastapi_websocket_forwards_etl_args(self):
+        """FastAPIServer forwards etl_args on the WebSocket direct-put hop."""
+        server = DummyFastAPIServer()
+        client = TestClient(server.app)
+        direct_put_url = "http://localhost:8080/ais/@/etl_dst/final"
+
+        with patch.object(server, "client", new=AsyncMock()) as mock_client:
+            mock_client.put.return_value = AsyncMock(status_code=200, content=b"")
+            with client.websocket_connect("/ws") as websocket:
+                websocket.send_json(
+                    data={ETL_WS_PIPELINE: direct_put_url, QPARAM_ETL_ARGS: "jpeg"},
+                    mode="binary",
+                )
+                websocket.send_bytes(b"testdata")
+                websocket.receive_text()
+
+            called_url = mock_client.put.call_args.args[0]
+            self.assertEqual(
+                parse_qs(urlparse(called_url).query)[QPARAM_ETL_ARGS], ["jpeg"]
+            )
+
+    @unittest.skipIf(sys.version_info < (3, 9), "requires Python 3.9 or higher")
+    def test_flask_buffered_forwards_etl_args(self):
+        """FlaskServer forwards etl_args on the buffered direct-put hop."""
+        server = DummyFlaskServer()
+        client = server.app.test_client()
+        headers = {HEADER_NODE_URL: "http://localhost:8080/ais/@/etl_dst/test/object"}
+
+        with patch("requests.Session.put") as mock_put:
+            mock_put.return_value = MagicMock(status_code=200, content=b"")
+            response = client.put(
+                "/test/object?etl_args=jpeg", data=b"input data", headers=headers
+            )
+
+            self.assertEqual(response.status_code, 204)
+            called_url = mock_put.call_args.args[0]
+            self.assertEqual(
+                parse_qs(urlparse(called_url).query)[QPARAM_ETL_ARGS], ["jpeg"]
+            )
+
+    def test_flask_streaming_forwards_etl_args(self):
+        """FlaskServer forwards etl_args on the streaming direct-put hop."""
+        server = DummyFlaskServer()
+        server.session = MagicMock()
+        server.session.put.return_value = MagicMock(status_code=200, content=b"")
+
+        # pylint: disable=protected-access
+        server._direct_put_stream(
+            "http://localhost:8080/ais/@/etl_dst/obj",
+            iter([b"chunk"]),
+            "",
+            "bucket/obj",
+            "jpeg",
+        )
+
+        called_url = server.session.put.call_args.args[0]
+        self.assertEqual(
+            parse_qs(urlparse(called_url).query)[QPARAM_ETL_ARGS], ["jpeg"]
+        )


### PR DESCRIPTION
This fixes `etl_args` propagation across direct-put ETL pipeline hops.

Before this change, the first ETL stage received per-request transform args from the target request, but downstream stages only received the transformed bytes and remaining pipeline header. As a result, stages 2..N saw empty `etl_args`.

Changes:
- Forward incoming `etl_args` through Go ETL direct-put and WebSocket pipeline paths.
- Forward incoming `etl_args` through Python FastAPI, Flask, and `HTTPMultiThreadedServer` direct-put paths.
- Preserve existing direct-put destination query params such as `uuid` / `owt`.
- Add Go and Python unit coverage for direct-put argument forwarding.