### PR TITLE
authn: add Redis KV backend for multi-replica AuthN

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,54 @@
+AIStore includes the following third-party software with their respective licenses:
+
+--------------------------------------------------------------------------------
+github.com/redis/go-redis/v9
+Copyright (c) 2013 The github.com/redis/go-redis Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+github.com/alicebob/miniredis/v2
+The MIT License (MIT)
+
+Copyright (c) 2014 Harmen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--------------------------------------------------------------------------------

--- a/api/authn/config.go
+++ b/api/authn/config.go
@@ -37,7 +37,9 @@ const (
 	defaultPort             = 52001
 	defaultTokenExpiration  = cos.Duration(24 * time.Hour)
 	defaultMaxTokenAge      = cos.Duration(90 * 24 * time.Hour)
-	defaultKVServiceAddr    = "localhost:6379"
+	defaultKVServiceHost    = "localhost"
+	defaultKVServicePort    = 6379
+	defaultKVServiceTimeout = cos.Duration(5 * time.Second)
 )
 
 // Signing key management modes
@@ -48,7 +50,15 @@ const (
 	SigningKeyModeExternal = "external"
 )
 
+// AuthN database backends.
+const (
+	DBDriverBuntDB DBDriver = "BuntDB"
+	DBDriverRedis  DBDriver = "Redis"
+)
+
 type (
+	DBDriver string
+
 	Config struct {
 		Server  ServerConf  `json:"auth"`
 		Log     LogConf     `json:"log"`
@@ -92,15 +102,17 @@ type (
 		Mode string `json:"mode,omitempty"`
 	}
 	DatabaseConf struct {
-		DBType   string        `json:"type"`
+		DBType   DBDriver      `json:"type"`
 		Filepath string        `json:"filepath"`
 		Service  KVServiceConf `json:"service"`
 	}
 	KVServiceConf struct {
-		Addr       string `json:"addr,omitempty"`
-		Password   string `json:"password,omitempty"` //nolint:gosec // configuration field, not a hardcoded credential
-		DBIndex    int    `json:"db_index,omitempty"`
-		TLSEnabled bool   `json:"tls_enabled,omitempty"`
+		password   cmn.Censored `json:"-"`
+		Host       string       `json:"host,omitempty"`
+		Port       int          `json:"port,omitempty"`
+		DBIndex    int          `json:"db_index,omitempty"`
+		TLSEnabled bool         `json:"tls_enabled,omitempty"`
+		Timeout    cos.Duration `json:"timeout,omitempty"`
 	}
 
 	// TimeoutConf sets the default timeout for the HTTP client used by the auth manager
@@ -145,6 +157,14 @@ func (c *Config) Verbose() bool {
 
 func (c *Config) Secret() cmn.Censored {
 	return cmn.Censored(*c.Server.psecret)
+}
+
+func (c *KVServiceConf) SetPassword(password string) {
+	c.password = cmn.Censored(password)
+}
+
+func (c *KVServiceConf) Password() string {
+	return string(c.password)
 }
 
 func (c *Config) Validate() error {
@@ -202,11 +222,29 @@ func (c *SigningKeyConf) validate() error {
 }
 
 func (c *DatabaseConf) validate() error {
+	if c.DBType != "" && c.DBType != DBDriverBuntDB && c.DBType != DBDriverRedis {
+		return fmt.Errorf("invalid auth.db.type=%q (valid values: %q, %q, or empty)",
+			c.DBType, DBDriverBuntDB, DBDriverRedis)
+	}
 	if c.Service.DBIndex < 0 {
 		return fmt.Errorf("invalid auth.db.service.db_index=%d (must be >= 0)", c.Service.DBIndex)
 	}
-	if c.DBType == "Redis" && c.Service.Addr == "" {
-		c.Service.Addr = defaultKVServiceAddr
+	if c.Service.Port != 0 && (c.Service.Port < minPort || c.Service.Port > maxPort) {
+		return fmt.Errorf("invalid auth.db.service.port=%d (expected %d-%d)", c.Service.Port, minPort, maxPort)
+	}
+	if c.Service.Timeout != 0 && c.Service.Timeout < minTimeout {
+		return fmt.Errorf("invalid auth.db.service.timeout=%s (expected >= %s)", c.Service.Timeout, minTimeout)
+	}
+	if c.DBType == DBDriverRedis {
+		if c.Service.Host == "" {
+			c.Service.Host = defaultKVServiceHost
+		}
+		if c.Service.Port == 0 {
+			c.Service.Port = defaultKVServicePort
+		}
+		if c.Service.Timeout == 0 {
+			c.Service.Timeout = defaultKVServiceTimeout
+		}
 	}
 	return nil
 }

--- a/api/authn/config.go
+++ b/api/authn/config.go
@@ -37,6 +37,7 @@ const (
 	defaultPort             = 52001
 	defaultTokenExpiration  = cos.Duration(24 * time.Hour)
 	defaultMaxTokenAge      = cos.Duration(90 * 24 * time.Hour)
+	defaultKVServiceAddr    = "localhost:6379"
 )
 
 // Signing key management modes
@@ -91,8 +92,15 @@ type (
 		Mode string `json:"mode,omitempty"`
 	}
 	DatabaseConf struct {
-		DBType   string `json:"type"`
-		Filepath string `json:"filepath"`
+		DBType   string        `json:"type"`
+		Filepath string        `json:"filepath"`
+		Service  KVServiceConf `json:"service"`
+	}
+	KVServiceConf struct {
+		Addr       string `json:"addr,omitempty"`
+		Password   string `json:"password,omitempty"` //nolint:gosec // configuration field, not a hardcoded credential
+		DBIndex    int    `json:"db_index,omitempty"`
+		TLSEnabled bool   `json:"tls_enabled,omitempty"`
 	}
 
 	// TimeoutConf sets the default timeout for the HTTP client used by the auth manager
@@ -162,6 +170,9 @@ func (c *ServerConf) Validate() error {
 	if err := c.SigningKey.validate(); err != nil {
 		return err
 	}
+	if err := c.DBConf.validate(); err != nil {
+		return err
+	}
 	if c.Expire == 0 {
 		c.Expire = defaultTokenExpiration
 	}
@@ -186,6 +197,16 @@ func (c *SigningKeyConf) validate() error {
 	}
 	if c.Mode != "" && c.Mode != SigningKeyModeExternal {
 		return fmt.Errorf("invalid auth.signing_key.mode=%q (valid values: %q or empty)", c.Mode, SigningKeyModeExternal)
+	}
+	return nil
+}
+
+func (c *DatabaseConf) validate() error {
+	if c.Service.DBIndex < 0 {
+		return fmt.Errorf("invalid auth.db.service.db_index=%d (must be >= 0)", c.Service.DBIndex)
+	}
+	if c.DBType == "Redis" && c.Service.Addr == "" {
+		c.Service.Addr = defaultKVServiceAddr
 	}
 	return nil
 }

--- a/api/authn/config_internal_test.go
+++ b/api/authn/config_internal_test.go
@@ -123,23 +123,32 @@ func TestDatabaseConfValidate(t *testing.T) {
 	t.Run("ServiceAccepted", func(t *testing.T) {
 		conf := DatabaseConf{
 			Service: KVServiceConf{
-				Addr:       "kv.authn.svc:6379",
-				Password:   "secret",
+				Host:       "kv.authn.svc",
+				Port:       6379,
 				DBIndex:    2,
 				TLSEnabled: true,
+				Timeout:    cos.Duration(2 * time.Second),
 			},
 		}
 		tassert.CheckFatal(t, conf.validate())
 	})
-	t.Run("RedisDefaultAddr", func(t *testing.T) {
-		conf := DatabaseConf{DBType: "Redis"}
+	t.Run("RedisDefaultService", func(t *testing.T) {
+		conf := DatabaseConf{DBType: DBDriverRedis}
 		tassert.CheckFatal(t, conf.validate())
-		tassert.Errorf(t, conf.Service.Addr == defaultKVServiceAddr,
-			"expected Redis service addr default %q, got %q", defaultKVServiceAddr, conf.Service.Addr)
+		tassert.Errorf(t, conf.Service.Host == defaultKVServiceHost,
+			"expected Redis service host default %q, got %q", defaultKVServiceHost, conf.Service.Host)
+		tassert.Errorf(t, conf.Service.Port == defaultKVServicePort,
+			"expected Redis service port default %d, got %d", defaultKVServicePort, conf.Service.Port)
+		tassert.Errorf(t, conf.Service.Timeout == defaultKVServiceTimeout,
+			"expected Redis service timeout default %s, got %s", defaultKVServiceTimeout, conf.Service.Timeout)
 	})
 	t.Run("NegativeDBIndexRejected", func(t *testing.T) {
 		conf := DatabaseConf{Service: KVServiceConf{DBIndex: -1}}
 		tassert.Errorf(t, conf.validate() != nil, "expected error for negative service db_index")
+	})
+	t.Run("InvalidDBTypeRejected", func(t *testing.T) {
+		conf := DatabaseConf{DBType: "customDB"}
+		tassert.Errorf(t, conf.validate() != nil, "expected error for invalid db type")
 	})
 }
 
@@ -180,6 +189,9 @@ func TestConfigValidateInvalid(t *testing.T) {
 		{"signing key bits too small", func(c *Config) { c.Server.SigningKey.Bits = minRSAKeyBits - 1 }},
 		{"signing key mode invalid", func(c *Config) { c.Server.SigningKey.Mode = "auto" }},
 		{"db service index invalid", func(c *Config) { c.Server.DBConf.Service.DBIndex = -1 }},
+		{"db service port too low", func(c *Config) { c.Server.DBConf.Service.Port = minPort - 1 }},
+		{"db service port too high", func(c *Config) { c.Server.DBConf.Service.Port = maxPort + 1 }},
+		{"db service timeout too short", func(c *Config) { c.Server.DBConf.Service.Timeout = minTimeout - 1 }},
 		{"bad log level", func(c *Config) { c.Log.Level = "verbose" }},
 		{"log level too low", func(c *Config) { c.Log.Level = "-1" }},
 		{"log level too high", func(c *Config) { c.Log.Level = "6" }},

--- a/api/authn/config_internal_test.go
+++ b/api/authn/config_internal_test.go
@@ -115,6 +115,34 @@ func TestSigningKeyConfValidate(t *testing.T) {
 	})
 }
 
+func TestDatabaseConfValidate(t *testing.T) {
+	t.Run("EmptyServiceAccepted", func(t *testing.T) {
+		conf := DatabaseConf{}
+		tassert.CheckFatal(t, conf.validate())
+	})
+	t.Run("ServiceAccepted", func(t *testing.T) {
+		conf := DatabaseConf{
+			Service: KVServiceConf{
+				Addr:       "kv.authn.svc:6379",
+				Password:   "secret",
+				DBIndex:    2,
+				TLSEnabled: true,
+			},
+		}
+		tassert.CheckFatal(t, conf.validate())
+	})
+	t.Run("RedisDefaultAddr", func(t *testing.T) {
+		conf := DatabaseConf{DBType: "Redis"}
+		tassert.CheckFatal(t, conf.validate())
+		tassert.Errorf(t, conf.Service.Addr == defaultKVServiceAddr,
+			"expected Redis service addr default %q, got %q", defaultKVServiceAddr, conf.Service.Addr)
+	})
+	t.Run("NegativeDBIndexRejected", func(t *testing.T) {
+		conf := DatabaseConf{Service: KVServiceConf{DBIndex: -1}}
+		tassert.Errorf(t, conf.validate() != nil, "expected error for negative service db_index")
+	})
+}
+
 func TestServerConfValidateLegacyRSAKeyBits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -151,6 +179,7 @@ func TestConfigValidateInvalid(t *testing.T) {
 		{"expire too short", func(c *Config) { c.Server.Expire = MinAuthExpiration - 1 }},
 		{"signing key bits too small", func(c *Config) { c.Server.SigningKey.Bits = minRSAKeyBits - 1 }},
 		{"signing key mode invalid", func(c *Config) { c.Server.SigningKey.Mode = "auto" }},
+		{"db service index invalid", func(c *Config) { c.Server.DBConf.Service.DBIndex = -1 }},
 		{"bad log level", func(c *Config) { c.Log.Level = "verbose" }},
 		{"log level too low", func(c *Config) { c.Log.Level = "-1" }},
 		{"log level too high", func(c *Config) { c.Log.Level = "6" }},

--- a/api/env/authn.go
+++ b/api/env/authn.go
@@ -26,6 +26,10 @@ const (
 	AisAuthPrivateKeyFile = "AIS_AUTHN_PRIVATE_KEY_FILE"
 	AisAuthPrivateKeyPass = "AIS_AUTHN_PRIVATE_KEY_PASS" // optional passphrase for encrypting private key on disk
 	AisAuthPublicKey      = "AIS_AUTHN_PUBLIC_KEY"       // for asymmetric tokens
+	AisAuthKVAddr         = "AIS_AUTHN_KV_ADDR"          // external KV service address for AuthN DB backends
+	AisAuthKVPassword     = "AIS_AUTHN_KV_PASSWORD"      // optional external KV service password
+	AisAuthKVDBIndex      = "AIS_AUTHN_KV_DB_INDEX"      // optional external KV service database/index
+	AisAuthKVTLS          = "AIS_AUTHN_KV_TLS"           // optional TLS toggle for external KV service
 	AisAuthAdminUsername  = "AIS_AUTHN_SU_NAME"
 	AisAuthAdminPassword  = "AIS_AUTHN_SU_PASS"
 )

--- a/api/env/authn.go
+++ b/api/env/authn.go
@@ -26,10 +26,7 @@ const (
 	AisAuthPrivateKeyFile = "AIS_AUTHN_PRIVATE_KEY_FILE"
 	AisAuthPrivateKeyPass = "AIS_AUTHN_PRIVATE_KEY_PASS" // optional passphrase for encrypting private key on disk
 	AisAuthPublicKey      = "AIS_AUTHN_PUBLIC_KEY"       // for asymmetric tokens
-	AisAuthKVAddr         = "AIS_AUTHN_KV_ADDR"          // external KV service address for AuthN DB backends
 	AisAuthKVPassword     = "AIS_AUTHN_KV_PASSWORD"      // optional external KV service password
-	AisAuthKVDBIndex      = "AIS_AUTHN_KV_DB_INDEX"      // optional external KV service database/index
-	AisAuthKVTLS          = "AIS_AUTHN_KV_TLS"           // optional TLS toggle for external KV service
 	AisAuthAdminUsername  = "AIS_AUTHN_SU_NAME"
 	AisAuthAdminPassword  = "AIS_AUTHN_SU_PASS"
 )

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -266,6 +266,35 @@ func (cm *ConfManager) GetDBPath() string {
 	return filepath.Join(filepath.Dir(cm.filePath), fname.AuthNDB)
 }
 
+func (cm *ConfManager) GetKVServiceConf() authn.KVServiceConf {
+	conf := cm.conf.Load().Server.DBConf.Service
+	if v := os.Getenv(env.AisAuthKVAddr); v != "" {
+		conf.Addr = v
+	}
+	if v := os.Getenv(env.AisAuthKVPassword); v != "" {
+		conf.Password = v
+	}
+	if v := os.Getenv(env.AisAuthKVDBIndex); v != "" {
+		idx, err := strconv.Atoi(v)
+		if err != nil {
+			nlog.Errorf("Failed to parse %s=%q: %v. Using config value %d",
+				env.AisAuthKVDBIndex, v, err, conf.DBIndex)
+		} else if idx < 0 {
+			nlog.Errorf("Invalid %s=%q (must be >= 0). Using config value %d",
+				env.AisAuthKVDBIndex, v, conf.DBIndex)
+		} else {
+			conf.DBIndex = idx
+		}
+	}
+	tlsEnabled, err := cos.IsParseEnvBoolOrDefault(env.AisAuthKVTLS, conf.TLSEnabled)
+	if err != nil {
+		nlog.Errorf("Failed to parse %s: %v. Using config value %t", env.AisAuthKVTLS, err, conf.TLSEnabled)
+	} else {
+		conf.TLSEnabled = tlsEnabled
+	}
+	return conf
+}
+
 func (cm *ConfManager) GetExternalURL() *url.URL {
 	return cm.externalURL
 }

--- a/cmd/authn/config/cmgr.go
+++ b/cmd/authn/config/cmgr.go
@@ -254,7 +254,7 @@ func (*ConfManager) GetJWKSMaxAge() int {
 	return int(defaultJWKSMaxAge.Seconds())
 }
 
-func (cm *ConfManager) GetDBType() string {
+func (cm *ConfManager) GetDBType() authn.DBDriver {
 	return cm.conf.Load().Server.DBConf.DBType
 }
 
@@ -268,29 +268,8 @@ func (cm *ConfManager) GetDBPath() string {
 
 func (cm *ConfManager) GetKVServiceConf() authn.KVServiceConf {
 	conf := cm.conf.Load().Server.DBConf.Service
-	if v := os.Getenv(env.AisAuthKVAddr); v != "" {
-		conf.Addr = v
-	}
 	if v := os.Getenv(env.AisAuthKVPassword); v != "" {
-		conf.Password = v
-	}
-	if v := os.Getenv(env.AisAuthKVDBIndex); v != "" {
-		idx, err := strconv.Atoi(v)
-		if err != nil {
-			nlog.Errorf("Failed to parse %s=%q: %v. Using config value %d",
-				env.AisAuthKVDBIndex, v, err, conf.DBIndex)
-		} else if idx < 0 {
-			nlog.Errorf("Invalid %s=%q (must be >= 0). Using config value %d",
-				env.AisAuthKVDBIndex, v, conf.DBIndex)
-		} else {
-			conf.DBIndex = idx
-		}
-	}
-	tlsEnabled, err := cos.IsParseEnvBoolOrDefault(env.AisAuthKVTLS, conf.TLSEnabled)
-	if err != nil {
-		nlog.Errorf("Failed to parse %s: %v. Using config value %t", env.AisAuthKVTLS, err, conf.TLSEnabled)
-	} else {
-		conf.TLSEnabled = tlsEnabled
+		conf.SetPassword(v)
 	}
 	return conf
 }

--- a/cmd/authn/config/cmgr_test.go
+++ b/cmd/authn/config/cmgr_test.go
@@ -198,6 +198,65 @@ func TestGetDBPath(t *testing.T) {
 	tassert.Errorf(t, got == expected, "expected %q, got %q", expected, got)
 }
 
+func TestGetKVServiceConf(t *testing.T) {
+	base := newBaseConfig()
+	base.Server.DBConf.Service = authn.KVServiceConf{
+		Addr:       "kv.authn.svc:6379",
+		Password:   "config-password",
+		DBIndex:    3,
+		TLSEnabled: true,
+	}
+	cm := newConfManagerWithConf(t, base)
+
+	got := cm.GetKVServiceConf()
+	tassert.Errorf(t, got.Addr == "kv.authn.svc:6379", "expected addr from config, got %q", got.Addr)
+	tassert.Errorf(t, got.Password == "config-password", "expected password from config, got %q", got.Password)
+	tassert.Errorf(t, got.DBIndex == 3, "expected db index from config, got %d", got.DBIndex)
+	tassert.Errorf(t, got.TLSEnabled, "expected TLS from config")
+}
+
+func TestGetKVServiceConfEnv(t *testing.T) {
+	base := newBaseConfig()
+	base.Server.DBConf.Service = authn.KVServiceConf{
+		Addr:       "config:6379",
+		Password:   "config-password",
+		DBIndex:    1,
+		TLSEnabled: false,
+	}
+	cm := newConfManagerWithConf(t, base)
+
+	t.Setenv(env.AisAuthKVAddr, "env:6379")
+	t.Setenv(env.AisAuthKVPassword, "env-password")
+	t.Setenv(env.AisAuthKVDBIndex, "4")
+	t.Setenv(env.AisAuthKVTLS, "true")
+
+	got := cm.GetKVServiceConf()
+	tassert.Errorf(t, got.Addr == "env:6379", "expected addr from env, got %q", got.Addr)
+	tassert.Errorf(t, got.Password == "env-password", "expected password from env, got %q", got.Password)
+	tassert.Errorf(t, got.DBIndex == 4, "expected db index from env, got %d", got.DBIndex)
+	tassert.Errorf(t, got.TLSEnabled, "expected TLS from env")
+}
+
+func TestGetKVServiceConfInvalidEnv(t *testing.T) {
+	base := newBaseConfig()
+	base.Server.DBConf.Service = authn.KVServiceConf{
+		DBIndex:    2,
+		TLSEnabled: true,
+	}
+	cm := newConfManagerWithConf(t, base)
+
+	t.Setenv(env.AisAuthKVDBIndex, "not-an-int")
+	t.Setenv(env.AisAuthKVTLS, "not-a-bool")
+
+	got := cm.GetKVServiceConf()
+	tassert.Errorf(t, got.DBIndex == 2, "expected config db index after invalid env, got %d", got.DBIndex)
+	tassert.Errorf(t, got.TLSEnabled, "expected config TLS after invalid env")
+
+	t.Setenv(env.AisAuthKVDBIndex, "-1")
+	got = cm.GetKVServiceConf()
+	tassert.Errorf(t, got.DBIndex == 2, "expected config db index after negative env, got %d", got.DBIndex)
+}
+
 func TestGetLogFlushInterval(t *testing.T) {
 	base := newBaseConfig()
 	expected := 20 * time.Second

--- a/cmd/authn/config/cmgr_test.go
+++ b/cmd/authn/config/cmgr_test.go
@@ -171,7 +171,7 @@ func TestGetDBType(t *testing.T) {
 	cm.Init(path)
 	tassert.Errorf(t, cm.GetDBType() == "", "expected empty db type, got %s", cm.GetDBType())
 	// Test DB from config is loaded
-	expected := "customDB"
+	expected := authn.DBDriverRedis
 	base.Server.DBConf = authn.DatabaseConf{DBType: expected}
 	path = writeConfToDisk(t, base)
 	cm2 := config.NewConfManager()
@@ -201,60 +201,41 @@ func TestGetDBPath(t *testing.T) {
 func TestGetKVServiceConf(t *testing.T) {
 	base := newBaseConfig()
 	base.Server.DBConf.Service = authn.KVServiceConf{
-		Addr:       "kv.authn.svc:6379",
-		Password:   "config-password",
+		Host:       "kv.authn.svc",
+		Port:       6379,
 		DBIndex:    3,
 		TLSEnabled: true,
+		Timeout:    cos.Duration(2 * time.Second),
 	}
 	cm := newConfManagerWithConf(t, base)
 
 	got := cm.GetKVServiceConf()
-	tassert.Errorf(t, got.Addr == "kv.authn.svc:6379", "expected addr from config, got %q", got.Addr)
-	tassert.Errorf(t, got.Password == "config-password", "expected password from config, got %q", got.Password)
+	tassert.Errorf(t, got.Host == "kv.authn.svc", "expected host from config, got %q", got.Host)
+	tassert.Errorf(t, got.Port == 6379, "expected port from config, got %d", got.Port)
 	tassert.Errorf(t, got.DBIndex == 3, "expected db index from config, got %d", got.DBIndex)
 	tassert.Errorf(t, got.TLSEnabled, "expected TLS from config")
+	tassert.Errorf(t, got.Timeout == cos.Duration(2*time.Second), "expected timeout from config, got %s", got.Timeout)
 }
 
-func TestGetKVServiceConfEnv(t *testing.T) {
+func TestGetKVServiceConfPasswordEnv(t *testing.T) {
 	base := newBaseConfig()
 	base.Server.DBConf.Service = authn.KVServiceConf{
-		Addr:       "config:6379",
-		Password:   "config-password",
+		Host:       "config",
+		Port:       6379,
 		DBIndex:    1,
 		TLSEnabled: false,
+		Timeout:    cos.Duration(2 * time.Second),
 	}
 	cm := newConfManagerWithConf(t, base)
 
-	t.Setenv(env.AisAuthKVAddr, "env:6379")
 	t.Setenv(env.AisAuthKVPassword, "env-password")
-	t.Setenv(env.AisAuthKVDBIndex, "4")
-	t.Setenv(env.AisAuthKVTLS, "true")
 
 	got := cm.GetKVServiceConf()
-	tassert.Errorf(t, got.Addr == "env:6379", "expected addr from env, got %q", got.Addr)
-	tassert.Errorf(t, got.Password == "env-password", "expected password from env, got %q", got.Password)
-	tassert.Errorf(t, got.DBIndex == 4, "expected db index from env, got %d", got.DBIndex)
-	tassert.Errorf(t, got.TLSEnabled, "expected TLS from env")
-}
-
-func TestGetKVServiceConfInvalidEnv(t *testing.T) {
-	base := newBaseConfig()
-	base.Server.DBConf.Service = authn.KVServiceConf{
-		DBIndex:    2,
-		TLSEnabled: true,
-	}
-	cm := newConfManagerWithConf(t, base)
-
-	t.Setenv(env.AisAuthKVDBIndex, "not-an-int")
-	t.Setenv(env.AisAuthKVTLS, "not-a-bool")
-
-	got := cm.GetKVServiceConf()
-	tassert.Errorf(t, got.DBIndex == 2, "expected config db index after invalid env, got %d", got.DBIndex)
-	tassert.Errorf(t, got.TLSEnabled, "expected config TLS after invalid env")
-
-	t.Setenv(env.AisAuthKVDBIndex, "-1")
-	got = cm.GetKVServiceConf()
-	tassert.Errorf(t, got.DBIndex == 2, "expected config db index after negative env, got %d", got.DBIndex)
+	tassert.Errorf(t, got.Host == "config", "expected host from config, got %q", got.Host)
+	tassert.Errorf(t, got.Port == 6379, "expected port from config, got %d", got.Port)
+	tassert.Errorf(t, got.Password() == "env-password", "expected password from env, got %q", got.Password())
+	tassert.Errorf(t, got.DBIndex == 1, "expected db index from config, got %d", got.DBIndex)
+	tassert.Errorf(t, !got.TLSEnabled, "expected TLS from config")
 }
 
 func TestGetLogFlushInterval(t *testing.T) {

--- a/cmd/authn/kvdb/kvdb.go
+++ b/cmd/authn/kvdb/kvdb.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/NVIDIA/aistore/api/authn"
 	"github.com/NVIDIA/aistore/cmd/authn/config"
 	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/cmn/kvdb"
@@ -21,6 +22,7 @@ type dbType string
 const (
 	EmptyDB dbType = ""
 	BuntDB  dbType = "BuntDB"
+	RedisDB dbType = "Redis"
 )
 
 const KeyMetadataVersion = 1
@@ -104,14 +106,15 @@ func (d *Driver) PersistKeyData(m *KeyData) error {
 }
 
 func CreateDriver(cm *config.ConfManager) *Driver {
-	dbPath := cm.GetDBPath()
 	switch dbType(cm.GetDBType()) {
 	case EmptyDB, BuntDB:
-		return &Driver{Driver: createBuntDB(dbPath)}
+		return &Driver{Driver: createBuntDB(cm.GetDBPath())}
+	case RedisDB:
+		return &Driver{Driver: createRedisDB(cm.GetKVServiceConf())}
 	default:
 		cos.ExitLogf(
-			"Invalid database type provided in config: %q. Currently supported database types are: %q.",
-			cm.GetDBType(), BuntDB,
+			"Invalid database type provided in config: %q. Supported database types are: %q and %q.",
+			cm.GetDBType(), BuntDB, RedisDB,
 		)
 		return nil
 	}
@@ -121,6 +124,14 @@ func createBuntDB(path string) kvdb.Driver {
 	driver, err := kvdb.NewBuntDB(path)
 	if err != nil {
 		cos.ExitLogf("Failed to init local database: %v", err)
+	}
+	return driver
+}
+
+func createRedisDB(conf authn.KVServiceConf) kvdb.Driver {
+	driver, err := newRedisDriver(conf)
+	if err != nil {
+		cos.ExitLogf("Failed to init Redis database: %v", err)
 	}
 	return driver
 }

--- a/cmd/authn/kvdb/kvdb.go
+++ b/cmd/authn/kvdb/kvdb.go
@@ -17,14 +17,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
-type dbType string
-
-const (
-	EmptyDB dbType = ""
-	BuntDB  dbType = "BuntDB"
-	RedisDB dbType = "Redis"
-)
-
 const KeyMetadataVersion = 1
 
 // KeyData is the single unit of storage for auth key state (JWKS and future fields).
@@ -106,15 +98,15 @@ func (d *Driver) PersistKeyData(m *KeyData) error {
 }
 
 func CreateDriver(cm *config.ConfManager) *Driver {
-	switch dbType(cm.GetDBType()) {
-	case EmptyDB, BuntDB:
+	switch cm.GetDBType() {
+	case "", authn.DBDriverBuntDB:
 		return &Driver{Driver: createBuntDB(cm.GetDBPath())}
-	case RedisDB:
+	case authn.DBDriverRedis:
 		return &Driver{Driver: createRedisDB(cm.GetKVServiceConf())}
 	default:
 		cos.ExitLogf(
 			"Invalid database type provided in config: %q. Supported database types are: %q and %q.",
-			cm.GetDBType(), BuntDB, RedisDB,
+			cm.GetDBType(), authn.DBDriverBuntDB, authn.DBDriverRedis,
 		)
 		return nil
 	}

--- a/cmd/authn/kvdb/redis.go
+++ b/cmd/authn/kvdb/redis.go
@@ -7,11 +7,14 @@ package kvdb
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmn"
 	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/cmn/kvdb"
 
@@ -23,28 +26,35 @@ const redisScanCount = 256
 
 // redisDriver implements cmn/kvdb.Driver with the same collection/key layout as BuntDB.
 type redisDriver struct {
-	client *redis.Client
+	client  *redis.Client
+	timeout time.Duration
 }
 
 var _ kvdb.Driver = (*redisDriver)(nil)
 
 func newRedisDriver(conf authn.KVServiceConf) (*redisDriver, error) {
 	opts := &redis.Options{
-		Addr:     conf.Addr,
-		Password: conf.Password,
-		DB:       conf.DBIndex,
+		Addr:                  cmn.HostPort(conf.Host, strconv.Itoa(conf.Port)),
+		Password:              conf.Password(),
+		DB:                    conf.DBIndex,
+		ContextTimeoutEnabled: true,
 	}
 	if conf.TLSEnabled {
 		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
 	client := redis.NewClient(opts)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	driver := &redisDriver{client: client, timeout: conf.Timeout.D()}
+	ctx, cancel := driver.ctx()
 	defer cancel()
 	if err := client.Ping(ctx).Err(); err != nil {
 		_ = client.Close()
 		return nil, err
 	}
-	return &redisDriver{client: client}, nil
+	return driver, nil
+}
+
+func (r *redisDriver) ctx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), r.timeout)
 }
 
 func (r *redisDriver) Close() error {
@@ -69,7 +79,9 @@ func (r *redisDriver) Get(collection, key string, object any) (int, error) {
 
 func (r *redisDriver) SetString(collection, key, data string) (int, error) {
 	name := kvdb.MakePath(collection, key)
-	if err := r.client.Set(context.Background(), name, data, 0).Err(); err != nil {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	if err := r.client.Set(ctx, name, data, 0).Err(); err != nil {
 		return http.StatusInternalServerError, err
 	}
 	return http.StatusOK, nil
@@ -77,7 +89,9 @@ func (r *redisDriver) SetString(collection, key, data string) (int, error) {
 
 func (r *redisDriver) GetString(collection, key string) (string, int, error) {
 	name := kvdb.MakePath(collection, key)
-	val, err := r.client.Get(context.Background(), name).Result()
+	ctx, cancel := r.ctx()
+	defer cancel()
+	val, err := r.client.Get(ctx, name).Result()
 	if err != nil {
 		return redisToCommonErr(err, collection, key)
 	}
@@ -86,7 +100,9 @@ func (r *redisDriver) GetString(collection, key string) (string, int, error) {
 
 func (r *redisDriver) Delete(collection, key string) (int, error) {
 	name := kvdb.MakePath(collection, key)
-	n, err := r.client.Del(context.Background(), name).Result()
+	ctx, cancel := r.ctx()
+	defer cancel()
+	n, err := r.client.Del(ctx, name).Result()
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -99,11 +115,13 @@ func (r *redisDriver) Delete(collection, key string) (int, error) {
 
 func (r *redisDriver) DeleteCollection(collection string) (int, error) {
 	pattern := kvdb.MakePath(collection, "*")
-	return r.scan(pattern, func(keys []string) error {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	return r.scan(ctx, pattern, func(keys []string) error {
 		if len(keys) == 0 {
 			return nil
 		}
-		return r.client.Del(context.Background(), keys...).Err()
+		return r.client.Del(ctx, keys...).Err()
 	})
 }
 
@@ -111,7 +129,9 @@ func (r *redisDriver) List(collection, pattern string) ([]string, int, error) {
 	pattern = normalizePattern(pattern)
 	fullPattern := kvdb.MakePath(collection, pattern)
 	keys := make([]string, 0)
-	code, err := r.scan(fullPattern, func(batch []string) error {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	code, err := r.scan(ctx, fullPattern, func(batch []string) error {
 		for _, path := range batch {
 			_, key := kvdb.ParsePath(path)
 			if key != "" {
@@ -127,11 +147,13 @@ func (r *redisDriver) GetAll(collection, pattern string) (map[string]string, int
 	pattern = normalizePattern(pattern)
 	fullPattern := kvdb.MakePath(collection, pattern)
 	values := make(map[string]string)
-	code, err := r.scan(fullPattern, func(batch []string) error {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	code, err := r.scan(ctx, fullPattern, func(batch []string) error {
 		for _, path := range batch {
-			val, err := r.client.Get(context.Background(), path).Result()
+			val, err := r.client.Get(ctx, path).Result()
 			if err != nil {
-				if err == redis.Nil {
+				if errors.Is(err, redis.Nil) {
 					continue
 				}
 				return err
@@ -146,10 +168,10 @@ func (r *redisDriver) GetAll(collection, pattern string) (map[string]string, int
 	return values, code, err
 }
 
-func (r *redisDriver) scan(pattern string, fn func([]string) error) (int, error) {
+func (r *redisDriver) scan(ctx context.Context, pattern string, fn func([]string) error) (int, error) {
 	var cursor uint64
 	for {
-		keys, next, err := r.client.Scan(context.Background(), cursor, pattern, redisScanCount).Result()
+		keys, next, err := r.client.Scan(ctx, cursor, pattern, redisScanCount).Result()
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -171,7 +193,7 @@ func normalizePattern(pattern string) string {
 }
 
 func redisToCommonErr(err error, collection, key string) (string, int, error) {
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		what := collection
 		if key != "" {
 			what += " \"" + key + "\""

--- a/cmd/authn/kvdb/redis.go
+++ b/cmd/authn/kvdb/redis.go
@@ -1,0 +1,182 @@
+// Package kvdb contains authN server code for interacting with a persistent key-value store
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package kvdb
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/cmn/kvdb"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/redis/go-redis/v9"
+)
+
+const redisScanCount = 256
+
+// redisDriver implements cmn/kvdb.Driver with the same collection/key layout as BuntDB.
+type redisDriver struct {
+	client *redis.Client
+}
+
+var _ kvdb.Driver = (*redisDriver)(nil)
+
+func newRedisDriver(conf authn.KVServiceConf) (*redisDriver, error) {
+	opts := &redis.Options{
+		Addr:     conf.Addr,
+		Password: conf.Password,
+		DB:       conf.DBIndex,
+	}
+	if conf.TLSEnabled {
+		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	client := redis.NewClient(opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	return &redisDriver{client: client}, nil
+}
+
+func (r *redisDriver) Close() error {
+	return r.client.Close()
+}
+
+func (r *redisDriver) Set(collection, key string, object any) (int, error) {
+	b := cos.MustMarshal(object)
+	return r.SetString(collection, key, string(b))
+}
+
+func (r *redisDriver) Get(collection, key string, object any) (int, error) {
+	s, code, err := r.GetString(collection, key)
+	if err != nil {
+		return code, err
+	}
+	if err := jsoniter.Unmarshal([]byte(s), object); err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) SetString(collection, key, data string) (int, error) {
+	name := kvdb.MakePath(collection, key)
+	if err := r.client.Set(context.Background(), name, data, 0).Err(); err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) GetString(collection, key string) (string, int, error) {
+	name := kvdb.MakePath(collection, key)
+	val, err := r.client.Get(context.Background(), name).Result()
+	if err != nil {
+		return redisToCommonErr(err, collection, key)
+	}
+	return val, http.StatusOK, nil
+}
+
+func (r *redisDriver) Delete(collection, key string) (int, error) {
+	name := kvdb.MakePath(collection, key)
+	n, err := r.client.Del(context.Background(), name).Result()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	if n == 0 {
+		_, code, err := redisToCommonErr(redis.Nil, collection, key)
+		return code, err
+	}
+	return http.StatusOK, nil
+}
+
+func (r *redisDriver) DeleteCollection(collection string) (int, error) {
+	pattern := kvdb.MakePath(collection, "*")
+	return r.scan(pattern, func(keys []string) error {
+		if len(keys) == 0 {
+			return nil
+		}
+		return r.client.Del(context.Background(), keys...).Err()
+	})
+}
+
+func (r *redisDriver) List(collection, pattern string) ([]string, int, error) {
+	pattern = normalizePattern(pattern)
+	fullPattern := kvdb.MakePath(collection, pattern)
+	keys := make([]string, 0)
+	code, err := r.scan(fullPattern, func(batch []string) error {
+		for _, path := range batch {
+			_, key := kvdb.ParsePath(path)
+			if key != "" {
+				keys = append(keys, key)
+			}
+		}
+		return nil
+	})
+	return keys, code, err
+}
+
+func (r *redisDriver) GetAll(collection, pattern string) (map[string]string, int, error) {
+	pattern = normalizePattern(pattern)
+	fullPattern := kvdb.MakePath(collection, pattern)
+	values := make(map[string]string)
+	code, err := r.scan(fullPattern, func(batch []string) error {
+		for _, path := range batch {
+			val, err := r.client.Get(context.Background(), path).Result()
+			if err != nil {
+				if err == redis.Nil {
+					continue
+				}
+				return err
+			}
+			_, key := kvdb.ParsePath(path)
+			if key != "" {
+				values[key] = val
+			}
+		}
+		return nil
+	})
+	return values, code, err
+}
+
+func (r *redisDriver) scan(pattern string, fn func([]string) error) (int, error) {
+	var cursor uint64
+	for {
+		keys, next, err := r.client.Scan(context.Background(), cursor, pattern, redisScanCount).Result()
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		if err := fn(keys); err != nil {
+			return http.StatusInternalServerError, err
+		}
+		cursor = next
+		if cursor == 0 {
+			return http.StatusOK, nil
+		}
+	}
+}
+
+func normalizePattern(pattern string) string {
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+		return pattern + "*"
+	}
+	return pattern
+}
+
+func redisToCommonErr(err error, collection, key string) (string, int, error) {
+	if err == redis.Nil {
+		what := collection
+		if key != "" {
+			what += " \"" + key + "\""
+		}
+		return "", http.StatusNotFound, cos.NewErrNotFound(nil, what)
+	}
+	return "", http.StatusInternalServerError, err
+}

--- a/cmd/authn/kvdb/redis_internal_test.go
+++ b/cmd/authn/kvdb/redis_internal_test.go
@@ -1,0 +1,102 @@
+// Package kvdb contains authN server code for interacting with a persistent key-value store
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package kvdb
+
+import (
+	"errors"
+	"io/fs"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/tools/tassert"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+func newTestRedisDriver(t *testing.T) *redisDriver {
+	srv := miniredis.RunT(t)
+	driver, err := newRedisDriver(authn.KVServiceConf{Addr: srv.Addr()})
+	tassert.CheckFatal(t, err)
+	t.Cleanup(func() { _ = driver.Close() })
+	return driver
+}
+
+func TestRedisDriverSetGetDelete(t *testing.T) {
+	driver := newTestRedisDriver(t)
+
+	code, err := driver.SetString("users", "alice", "reader")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+
+	got, code, err := driver.GetString("users", "alice")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+	tassert.Errorf(t, got == "reader", "expected stored value, got %q", got)
+
+	code, err = driver.Delete("users", "alice")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+
+	got, code, err = driver.GetString("users", "alice")
+	tassert.Errorf(t, errors.Is(err, fs.ErrNotExist), "expected not-exist error, got %v", err)
+	tassert.Errorf(t, code == http.StatusNotFound, "expected status %d, got %d", http.StatusNotFound, code)
+	tassert.Errorf(t, got == "", "expected empty value after delete, got %q", got)
+}
+
+func TestRedisDriverListAndGetAll(t *testing.T) {
+	driver := newTestRedisDriver(t)
+
+	for key, val := range map[string]string{
+		"admin": "su",
+		"alice": "reader",
+		"bob":   "writer",
+	} {
+		_, err := driver.SetString("users", key, val)
+		tassert.CheckFatal(t, err)
+	}
+	_, err := driver.SetString("roles", "admin", "role")
+	tassert.CheckFatal(t, err)
+
+	keys, code, err := driver.List("users", "a")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+	sort.Strings(keys)
+	tassert.Errorf(t, len(keys) == 2 && keys[0] == "admin" && keys[1] == "alice",
+		"expected admin/alice keys, got %#v", keys)
+
+	values, code, err := driver.GetAll("users", "")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+	tassert.Errorf(t, len(values) == 3, "expected 3 users, got %#v", values)
+	tassert.Errorf(t, values["alice"] == "reader", "expected alice value, got %q", values["alice"])
+	tassert.Errorf(t, values["bob"] == "writer", "expected bob value, got %q", values["bob"])
+}
+
+func TestRedisDriverDeleteCollection(t *testing.T) {
+	driver := newTestRedisDriver(t)
+
+	_, err := driver.SetString("users", "alice", "reader")
+	tassert.CheckFatal(t, err)
+	_, err = driver.SetString("users", "bob", "writer")
+	tassert.CheckFatal(t, err)
+	_, err = driver.SetString("roles", "admin", "role")
+	tassert.CheckFatal(t, err)
+
+	code, err := driver.DeleteCollection("users")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+
+	users, code, err := driver.List("users", "")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+	tassert.Errorf(t, len(users) == 0, "expected users collection deleted, got %#v", users)
+
+	role, code, err := driver.GetString("roles", "admin")
+	tassert.CheckFatal(t, err)
+	tassert.Errorf(t, code == http.StatusOK, "expected status %d, got %d", http.StatusOK, code)
+	tassert.Errorf(t, role == "role", "expected other collection preserved, got %q", role)
+}

--- a/cmd/authn/kvdb/redis_internal_test.go
+++ b/cmd/authn/kvdb/redis_internal_test.go
@@ -7,11 +7,15 @@ package kvdb
 import (
 	"errors"
 	"io/fs"
+	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/aistore/api/authn"
+	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/tools/tassert"
 
 	"github.com/alicebob/miniredis/v2"
@@ -19,7 +23,15 @@ import (
 
 func newTestRedisDriver(t *testing.T) *redisDriver {
 	srv := miniredis.RunT(t)
-	driver, err := newRedisDriver(authn.KVServiceConf{Addr: srv.Addr()})
+	host, port, err := net.SplitHostPort(srv.Addr())
+	tassert.CheckFatal(t, err)
+	portNum, err := strconv.Atoi(port)
+	tassert.CheckFatal(t, err)
+	driver, err := newRedisDriver(authn.KVServiceConf{
+		Host:    host,
+		Port:    portNum,
+		Timeout: cos.Duration(5 * time.Second),
+	})
 	tassert.CheckFatal(t, err)
 	t.Cleanup(func() { _ = driver.Close() })
 	return driver

--- a/cmn/kvdb/api.go
+++ b/cmn/kvdb/api.go
@@ -25,6 +25,15 @@ import (
 
 const CollectionSepa = "##"
 
+// MakePath constructs a database key from a collection name and a key. Drivers
+// should use this helper so ParsePath can recover the same collection/key pair.
+func MakePath(collection, key string) string {
+	if strings.HasSuffix(collection, CollectionSepa) {
+		return collection + key
+	}
+	return collection + CollectionSepa + key
+}
+
 type (
 	Driver interface {
 		// A driver should sync data with local drives on close

--- a/cmn/kvdb/bunt.go
+++ b/cmn/kvdb/bunt.go
@@ -65,17 +65,6 @@ func buntToCommonErr(err error, collection, key string) (int, error) {
 	}
 }
 
-// Create "unique" key from collection and key, so there was no trouble when
-// there is an overlap. E.g, if key and collection uses the same separator
-// for subkeys, two pairs ("abc", "def/ghi") and ("abc/def", "ghi") generate
-// the same full path. The function should make them different.
-func makePath(collection, key string) string {
-	if strings.HasSuffix(collection, "##") {
-		return collection + key
-	}
-	return collection + CollectionSepa + key
-}
-
 func (bd *BuntDriver) Close() error {
 	return bd.driver.Close()
 }
@@ -97,7 +86,7 @@ func (bd *BuntDriver) Get(collection, key string, object any) (int, error) {
 }
 
 func (bd *BuntDriver) SetString(collection, key, data string) (int, error) {
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.Update(func(tx *buntdb.Tx) error {
 		_, _, err := tx.Set(name, data, nil)
 		return err
@@ -107,7 +96,7 @@ func (bd *BuntDriver) SetString(collection, key, data string) (int, error) {
 
 func (bd *BuntDriver) GetString(collection, key string) (string, int, error) {
 	var value string
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		var err error
 		value, err = tx.Get(name)
@@ -118,7 +107,7 @@ func (bd *BuntDriver) GetString(collection, key string) (string, int, error) {
 }
 
 func (bd *BuntDriver) Delete(collection, key string) (int, error) {
-	name := makePath(collection, key)
+	name := MakePath(collection, key)
 	err := bd.driver.Update(func(tx *buntdb.Tx) error {
 		_, err := tx.Delete(name)
 		return err
@@ -134,7 +123,7 @@ func (bd *BuntDriver) List(collection, pattern string) ([]string, int, error) {
 	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
 		pattern += "*"
 	}
-	filter = makePath(collection, pattern)
+	filter = MakePath(collection, pattern)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		tx.AscendKeys(filter, func(path, _ string) bool {
 			_, key := ParsePath(path)
@@ -174,7 +163,7 @@ func (bd *BuntDriver) GetAll(collection, pattern string) (map[string]string, int
 	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
 		pattern += "*"
 	}
-	filter = makePath(collection, pattern)
+	filter = MakePath(collection, pattern)
 	err := bd.driver.View(func(tx *buntdb.Tx) error {
 		tx.AscendKeys(filter, func(path, val string) bool {
 			_, key := ParsePath(path)

--- a/docs/authn.md
+++ b/docs/authn.md
@@ -349,10 +349,16 @@ Environment variables used by the AuthN server:
 | `AIS_AUTHN_SECRET_KEY`       | `""`                        | HMAC secret key used to sign tokens.                                                                                                                                  |    
 | `AIS_AUTHN_PRIVATE_KEY_FILE` | `""`                        | RSA private key file path (AuthN server)                                                                                                                              |
 | `AIS_AUTHN_PRIVATE_KEY_PASS` | `""`                        | RSA private key passphrase (AuthN server, optional)                                                                                                                   |
+| `AIS_AUTHN_KV_ADDR`          | `""`                        | External KV service address for AuthN database backends that use `auth.db.service`                                                                                    |
+| `AIS_AUTHN_KV_PASSWORD`      | `""`                        | External KV service password for AuthN database backends that use `auth.db.service`                                                                                   |
+| `AIS_AUTHN_KV_DB_INDEX`      | `0`                         | External KV service database/index for AuthN database backends that use `auth.db.service`                                                                             |
+| `AIS_AUTHN_KV_TLS`           | `false`                     | Enable TLS for external KV service connections                                                                                                                        |
 | `AIS_AUTHN_EXTERNAL_URL`     | `http[s]://localhost:52001` | URL for AIS clusters to use when validating AuthN as allowed issuer. See [External URL](#external-url) section                                                        |
 
 All variables can be set at AIStore cluster deployment and will override values in the config.
 * More info on env vars: [api/env/authn.go](https://github.com/NVIDIA/aistore/blob/main/api/env/authn.go)
+
+AuthN defaults to local BuntDB storage. Set `auth.db.type` to `Redis` and configure `auth.db.service` (or the corresponding `AIS_AUTHN_KV_*` environment variables) to share AuthN state across replicas through an external Redis service.
 
 Separately, configure the following AuthN environment variables for client access:
 
@@ -434,7 +440,17 @@ By default, the AIStore deployment does not launch the AuthN server. To start th
             }
         },
         "auth": {
-            "expiration_time": "24h"
+            "expiration_time": "24h",
+            "db": {
+                "type": "BuntDB",
+                "filepath": "/tmp/ais/authn/authn.db",
+                "service": {
+                    "addr": "",
+                    "password": "",
+                    "db_index": 0,
+                    "tls_enabled": false
+                }
+            }
         },
         "timeout": {
             "default_timeout": "30s"

--- a/docs/authn.md
+++ b/docs/authn.md
@@ -349,16 +349,13 @@ Environment variables used by the AuthN server:
 | `AIS_AUTHN_SECRET_KEY`       | `""`                        | HMAC secret key used to sign tokens.                                                                                                                                  |    
 | `AIS_AUTHN_PRIVATE_KEY_FILE` | `""`                        | RSA private key file path (AuthN server)                                                                                                                              |
 | `AIS_AUTHN_PRIVATE_KEY_PASS` | `""`                        | RSA private key passphrase (AuthN server, optional)                                                                                                                   |
-| `AIS_AUTHN_KV_ADDR`          | `""`                        | External KV service address for AuthN database backends that use `auth.db.service`                                                                                    |
 | `AIS_AUTHN_KV_PASSWORD`      | `""`                        | External KV service password for AuthN database backends that use `auth.db.service`                                                                                   |
-| `AIS_AUTHN_KV_DB_INDEX`      | `0`                         | External KV service database/index for AuthN database backends that use `auth.db.service`                                                                             |
-| `AIS_AUTHN_KV_TLS`           | `false`                     | Enable TLS for external KV service connections                                                                                                                        |
 | `AIS_AUTHN_EXTERNAL_URL`     | `http[s]://localhost:52001` | URL for AIS clusters to use when validating AuthN as allowed issuer. See [External URL](#external-url) section                                                        |
 
-All variables can be set at AIStore cluster deployment and will override values in the config.
+Variables can be set at AIStore cluster deployment and will override the corresponding values in the config when applicable.
 * More info on env vars: [api/env/authn.go](https://github.com/NVIDIA/aistore/blob/main/api/env/authn.go)
 
-AuthN defaults to local BuntDB storage. Set `auth.db.type` to `Redis` and configure `auth.db.service` (or the corresponding `AIS_AUTHN_KV_*` environment variables) to share AuthN state across replicas through an external Redis service.
+AuthN defaults to local BuntDB storage. Set `auth.db.type` to `Redis` and configure `auth.db.service` to share AuthN state across replicas through an external Redis service. Use `AIS_AUTHN_KV_PASSWORD` to inject the Redis password at runtime without persisting it in the config file.
 
 Separately, configure the following AuthN environment variables for client access:
 
@@ -445,10 +442,11 @@ By default, the AIStore deployment does not launch the AuthN server. To start th
                 "type": "BuntDB",
                 "filepath": "/tmp/ais/authn/authn.db",
                 "service": {
-                    "addr": "",
-                    "password": "",
+                    "host": "",
+                    "port": 0,
                     "db_index": 0,
-                    "tls_enabled": false
+                    "tls_enabled": false,
+                    "timeout": "0s"
                 }
             }
         },

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/NVIDIA/go-tfdata v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -28,6 +29,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/seiflotfy/cuckoofilter v0.0.0-20240715131351-a2f2c23f1771
 	github.com/teris-io/shortid v0.0.0-20220617161101-71ec9f2aa569
 	github.com/tidwall/buntdb v1.3.2
@@ -146,6 +148,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
@@ -154,6 +157,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/NVIDIA/go-tfdata v0.3.1 h1:Y+XIaSJO26Xh9ZjRrB+DdwC2O9OuPVpg/od4mT05hi
 github.com/NVIDIA/go-tfdata v0.3.1/go.mod h1:ZvMINggjz/OZ2wpkT8rFCDcdw1zDYdC3CVJSa4zGEXc=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
@@ -279,6 +281,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
+github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
@@ -338,6 +342,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
@@ -364,6 +370,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=


### PR DESCRIPTION
## Summary
- Add generic `auth.db.service` config plus `AIS_AUTHN_KV_*` environment overrides for external AuthN KV services.
- Add a Redis-backed AuthN KV driver selected with `auth.db.type = "Redis"`; local BuntDB remains the default backend.
- Share the same collection/key layout across BuntDB and Redis via `kvdb.MakePath`.
- Add Redis driver coverage with `miniredis` for set/get/delete/list/get-all/delete-collection behavior.
- Document Redis-based shared AuthN storage for multi-replica deployments and add third-party notices for the new Redis-related dependencies.

Closes #273.

## Testing
- `gofmt -w api/env/authn.go api/authn/config.go api/authn/config_internal_test.go cmd/authn/config/cmgr.go cmd/authn/config/cmgr_test.go cmd/authn/kvdb/kvdb.go cmd/authn/kvdb/redis.go cmd/authn/kvdb/redis_internal_test.go cmn/kvdb/api.go cmn/kvdb/bunt.go`
- `go test ./api/authn ./cmd/authn/config ./cmd/authn/kvdb ./cmd/authn/signing ./cmn/kvdb`
- `go test ./cmd/authn`
- `git diff --check`