### PR TITLE
object: add limited CSV select CLI prototype

### DIFF
--- a/cmd/cli/cli/const.go
+++ b/cmd/cli/cli/const.go
@@ -69,6 +69,7 @@ const (
 	commandPut       = "put"
 	commandRemove    = "rm"
 	commandRename    = "mv"
+	commandSelect    = "select"
 	commandSet       = "set"
 
 	// multipart upload commands
@@ -364,7 +365,8 @@ const (
 	mptCompleteArgument = objectArgument + " UPLOAD_ID PART_NUMBERS"
 	mptAbortArgument    = objectArgument + " UPLOAD_ID"
 
-	getObjectArgument = "BUCKET[/OBJECT_NAME] [OUT_FILE|OUT_DIR|-]"
+	getObjectArgument    = "BUCKET[/OBJECT_NAME] [OUT_FILE|OUT_DIR|-]"
+	selectObjectArgument = objectArgument + " --query QUERY"
 
 	optionalPrefixArgument = "BUCKET[/OBJECT_NAME_or_PREFIX]"
 	putObjectArgument      = "[-|FILE|DIRECTORY[/PATTERN]] " + optionalPrefixArgument

--- a/cmd/cli/cli/object_hdlr.go
+++ b/cmd/cli/cli/object_hdlr.go
@@ -204,6 +204,12 @@ var (
 			forceFlag,
 			encodeObjnameFlag,
 		},
+		commandSelect: {
+			objectSelectQueryFlag,
+			objectSelectInputFormatFlag,
+			objectSelectOutputFormatFlag,
+			encodeObjnameFlag,
+		},
 		cmdMptCreate: {
 			verboseFlag,
 		},
@@ -331,6 +337,14 @@ var (
 				ArgsUsage:    objectArgument,
 				Flags:        sortFlags(objectCmdsFlags[commandCat]),
 				Action:       catHandler,
+				BashComplete: bucketCompletions(bcmplop{separator: true}),
+			},
+			{
+				Name:         commandSelect,
+				Usage:        "Select rows and columns from a structured object",
+				ArgsUsage:    selectObjectArgument,
+				Flags:        sortFlags(objectCmdsFlags[commandSelect]),
+				Action:       objectSelectHandler,
 				BashComplete: bucketCompletions(bcmplop{separator: true}),
 			},
 			// multipart upload commands

--- a/cmd/cli/cli/object_select.go
+++ b/cmd/cli/cli/object_select.go
@@ -1,0 +1,288 @@
+// Package cli provides easy-to-use commands to manage, monitor, and utilize AIS clusters.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cli
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/NVIDIA/aistore/api"
+
+	"github.com/urfave/cli"
+)
+
+const (
+	objectSelectFormatCSV = "csv"
+)
+
+var (
+	objectSelectQueryFlag = cli.StringFlag{
+		Name:  "query,q",
+		Usage: "SQL-like projection and filter expression, e.g. \"SELECT col1,col2 WHERE col3 > 10\"",
+	}
+	objectSelectInputFormatFlag = cli.StringFlag{
+		Name:  "input-format",
+		Value: objectSelectFormatCSV,
+		Usage: "Input object format; currently supported: csv",
+	}
+	objectSelectOutputFormatFlag = cli.StringFlag{
+		Name:  "output-format",
+		Value: objectSelectFormatCSV,
+		Usage: "Output format; currently supported: csv",
+	}
+)
+
+type (
+	objectSelectQuery struct {
+		columns   []string
+		predicate *objectSelectPredicate
+	}
+
+	objectSelectPredicate struct {
+		column string
+		op     string
+		value  string
+	}
+)
+
+func objectSelectHandler(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return missingArgumentsError(c, c.Command.ArgsUsage)
+	}
+	query := parseStrFlag(c, objectSelectQueryFlag)
+	if query == "" {
+		return missingArgumentsError(c, flprn(objectSelectQueryFlag))
+	}
+	inputFormat := strings.ToLower(parseStrFlag(c, objectSelectInputFormatFlag))
+	if inputFormat != objectSelectFormatCSV {
+		return fmt.Errorf("unsupported %s=%q: currently supported format is %q",
+			flprn(objectSelectInputFormatFlag), inputFormat, objectSelectFormatCSV)
+	}
+	outputFormat := strings.ToLower(parseStrFlag(c, objectSelectOutputFormatFlag))
+	if outputFormat != objectSelectFormatCSV {
+		return fmt.Errorf("unsupported %s=%q: currently supported format is %q",
+			flprn(objectSelectOutputFormatFlag), outputFormat, objectSelectFormatCSV)
+	}
+
+	bck, objName, err := parseBckObjURI(c, c.Args().Get(0), false)
+	if err != nil {
+		return err
+	}
+	if objName == "" {
+		return missingArgumentsError(c, "object name in the form "+objectArgument)
+	}
+
+	var warned bool
+	encObjName := warnEscapeObjName(c, objName, &warned)
+	reader, _, err := api.GetObjectReader(apiBP, bck, encObjName, nil)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	return selectCSVObject(reader, c.App.Writer, query)
+}
+
+func parseObjectSelectQuery(query string) (*objectSelectQuery, error) {
+	const selectKeyword = "select "
+	trimmed := strings.TrimSpace(query)
+	if len(trimmed) < len(selectKeyword) || !strings.EqualFold(trimmed[:len(selectKeyword)], selectKeyword) {
+		return nil, fmt.Errorf("query must start with SELECT")
+	}
+
+	body := strings.TrimSpace(trimmed[len(selectKeyword):])
+	if body == "" {
+		return nil, fmt.Errorf("missing SELECT projection")
+	}
+
+	whereIdx := indexKeyword(body, "where")
+	projection := body
+	var where string
+	if whereIdx >= 0 {
+		projection = strings.TrimSpace(body[:whereIdx])
+		where = strings.TrimSpace(body[whereIdx+len("where"):])
+	}
+	if fromIdx := indexKeyword(projection, "from"); fromIdx >= 0 {
+		projection = strings.TrimSpace(projection[:fromIdx])
+	}
+	if projection == "" {
+		return nil, fmt.Errorf("missing SELECT projection")
+	}
+
+	parsed := &objectSelectQuery{}
+	if projection == "*" {
+		parsed.columns = []string{"*"}
+	} else {
+		cols := strings.Split(projection, ",")
+		for _, col := range cols {
+			col = strings.TrimSpace(col)
+			if col == "" {
+				return nil, fmt.Errorf("empty projection column in %q", projection)
+			}
+			parsed.columns = append(parsed.columns, col)
+		}
+	}
+
+	if where != "" {
+		predicate, err := parseObjectSelectPredicate(where)
+		if err != nil {
+			return nil, err
+		}
+		parsed.predicate = predicate
+	}
+	return parsed, nil
+}
+
+func parseObjectSelectPredicate(where string) (*objectSelectPredicate, error) {
+	for _, op := range []string{">=", "<=", "!=", "=", ">", "<"} {
+		if idx := strings.Index(where, op); idx >= 0 {
+			column := strings.TrimSpace(where[:idx])
+			value := strings.TrimSpace(where[idx+len(op):])
+			if column == "" || value == "" {
+				return nil, fmt.Errorf("invalid WHERE predicate %q", where)
+			}
+			value = strings.Trim(value, `"'`)
+			return &objectSelectPredicate{column: column, op: op, value: value}, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported WHERE predicate %q", where)
+}
+
+func indexKeyword(s, keyword string) int {
+	fields := strings.Fields(s)
+	offset := 0
+	for _, field := range fields {
+		idx := strings.Index(s[offset:], field)
+		if idx < 0 {
+			continue
+		}
+		offset += idx
+		if strings.EqualFold(field, keyword) {
+			return offset
+		}
+		offset += len(field)
+	}
+	return -1
+}
+
+func selectCSVObject(in io.Reader, out io.Writer, query string) error {
+	parsed, err := parseObjectSelectQuery(query)
+	if err != nil {
+		return err
+	}
+
+	reader := csv.NewReader(in)
+	reader.FieldsPerRecord = -1
+	header, err := reader.Read()
+	if err != nil {
+		return err
+	}
+	index := make(map[string]int, len(header))
+	for i, col := range header {
+		index[col] = i
+	}
+
+	projection, err := projectionIndexes(header, index, parsed.columns)
+	if err != nil {
+		return err
+	}
+	predicateIndex := -1
+	if parsed.predicate != nil {
+		var ok bool
+		predicateIndex, ok = index[parsed.predicate.column]
+		if !ok {
+			return fmt.Errorf("unknown WHERE column %q", parsed.predicate.column)
+		}
+	}
+
+	writer := csv.NewWriter(out)
+	if err := writer.Write(projectRecord(header, projection)); err != nil {
+		return err
+	}
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if predicateIndex >= len(record) {
+			return fmt.Errorf("record has %d fields, WHERE column %q expects field %d",
+				len(record), parsed.predicate.column, predicateIndex+1)
+		}
+		if parsed.predicate != nil && !matchObjectSelectPredicate(record[predicateIndex], parsed.predicate) {
+			continue
+		}
+		if err := writer.Write(projectRecord(record, projection)); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func projectionIndexes(header []string, index map[string]int, columns []string) ([]int, error) {
+	if len(columns) == 1 && columns[0] == "*" {
+		out := make([]int, len(header))
+		for i := range header {
+			out[i] = i
+		}
+		return out, nil
+	}
+
+	out := make([]int, 0, len(columns))
+	for _, col := range columns {
+		idx, ok := index[col]
+		if !ok {
+			return nil, fmt.Errorf("unknown SELECT column %q", col)
+		}
+		out = append(out, idx)
+	}
+	return out, nil
+}
+
+func projectRecord(record []string, projection []int) []string {
+	out := make([]string, 0, len(projection))
+	for _, idx := range projection {
+		if idx < len(record) {
+			out = append(out, record[idx])
+		} else {
+			out = append(out, "")
+		}
+	}
+	return out
+}
+
+func matchObjectSelectPredicate(got string, predicate *objectSelectPredicate) bool {
+	switch predicate.op {
+	case "=":
+		return got == predicate.value
+	case "!=":
+		return got != predicate.value
+	}
+
+	left, lerr := strconv.ParseFloat(got, 64)
+	right, rerr := strconv.ParseFloat(predicate.value, 64)
+	if lerr != nil || rerr != nil {
+		return false
+	}
+	switch predicate.op {
+	case ">":
+		return left > right
+	case "<":
+		return left < right
+	case ">=":
+		return left >= right
+	case "<=":
+		return left <= right
+	default:
+		return false
+	}
+}

--- a/cmd/cli/cli/object_select_test.go
+++ b/cmd/cli/cli/object_select_test.go
@@ -1,0 +1,67 @@
+// Package cli provides easy-to-use commands to manage, monitor, and utilize AIS clusters.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestObjectSelectCSVProjectionAndPredicate(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\nbeta,b,12\ngamma,b,3\n")
+	var output strings.Builder
+
+	err := selectCSVObject(input, &output, "SELECT name,score WHERE score > 10")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expected = "name,score\nbeta,12\n"
+	if got := output.String(); got != expected {
+		t.Fatalf("unexpected output:\nexpected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestObjectSelectCSVSelectAllWithStringPredicate(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\nbeta,b,12\ngamma,b,3\n")
+	var output strings.Builder
+
+	err := selectCSVObject(input, &output, `SELECT * WHERE kind = "b"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expected = "name,kind,score\nbeta,b,12\ngamma,b,3\n"
+	if got := output.String(); got != expected {
+		t.Fatalf("unexpected output:\nexpected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestObjectSelectCSVRejectsUnknownColumn(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\n")
+	var output strings.Builder
+
+	err := selectCSVObject(input, &output, "SELECT missing WHERE score > 10")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `unknown SELECT column "missing"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestObjectSelectQueryAllowsFromClause(t *testing.T) {
+	parsed, err := parseObjectSelectQuery("SELECT name, score FROM object WHERE score >= 10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.columns) != 2 || parsed.columns[0] != "name" || parsed.columns[1] != "score" {
+		t.Fatalf("unexpected columns: %#v", parsed.columns)
+	}
+	if parsed.predicate == nil || parsed.predicate.column != "score" ||
+		parsed.predicate.op != ">=" || parsed.predicate.value != "10" {
+		t.Fatalf("unexpected predicate: %#v", parsed.predicate)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ais object select` as a limited CLI prototype for #305.
- Support CSV input/output with SQL-like projection and simple predicates, for example `SELECT name,score WHERE score > 10`.
- Stream object contents through the existing object reader and write selected rows to stdout.
- Add unit coverage for projection, `SELECT *`, string/numeric predicates, unknown columns, and optional `FROM` syntax.

## Scope
This is intentionally a small first patch to show `ais object select` in action. It does not attempt S3 Select compatibility, Parquet, DuckDB embedding, or target-side execution yet. The current implementation uses the existing object GET path and keeps the query/evaluation logic isolated so the next stage can replace the executor with an AIS-native target-side implementation.

## Testing
- `go test ./cli`

Closes #305 only if maintainers decide this prototype is the desired first stage; otherwise it can serve as the discussion patch for stage-one requirements.