### PR TITLE
copy: retry remote cold-read t2t sends

### DIFF
--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -1793,6 +1793,9 @@ func (coi *coi) do(t *target, dm *bundle.DM, lom *core.LOM) (res xs.CoiRes) {
 			}
 			coi.OAH = resp.OAH
 			r = resp.R
+			if resp.Remote && r != nil {
+				return coi.sendRemoteColdRead(t, lom, tsi, resp)
+			}
 		}
 		return coi.send(t, dm, lom, r, tsi) // lom is the source of reader if no reader specified
 	}
@@ -2018,6 +2021,42 @@ func (coi *coi) _chunk(t *target, lom, dst *core.LOM, dstChunkSize int64) (res x
 	return res
 }
 
+func (coi *coi) sendRemoteColdRead(t *target, lom *core.LOM, tsi *meta.Snode, resp core.ReadResp) (res xs.CoiRes) {
+	const attempts = 3
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			resp = coi.GetROC(lom, coi.LatestVer, coi.Sync, coi.ETLArgs)
+			if resp.Err != nil {
+				return xs.CoiRes{Err: resp.Err, Ecode: resp.Ecode}
+			}
+			if !resp.Remote || resp.R == nil {
+				coi.OAH = resp.OAH
+				return coi.send(t, nil, lom, resp.R, tsi)
+			}
+		}
+
+		coi.OAH = resp.OAH
+		res = coi.send(t, nil, lom, resp.R, tsi)
+		if res.Err == nil || attempt == attempts-1 || !isRemoteColdCopyRetryable(res.Err) {
+			return res
+		}
+	}
+	return res
+}
+
+func isRemoteColdCopyRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || cos.IsErrRetriableConn(err) {
+		return true
+	}
+	errmsg := err.Error()
+	return strings.Contains(errmsg, "unexpected EOF") ||
+		(strings.Contains(errmsg, "read") && strings.Contains(errmsg, "shorter than size"))
+}
+
 // send object => designated target
 // * source is a LOM or a reader (that may be reading from remote)
 // * one of the two equivalent transmission mechanisms: PUT or transport Send
@@ -2069,6 +2108,9 @@ func (coi *coi) _send(t *target, lom *core.LOM, sargs *sendArgs) (res xs.CoiRes)
 		res.Err = coi._dm(lom /*for attrs*/, sargs)
 	} else {
 		res.Err = coi.put(t, sargs)
+	}
+	if res.Err == nil && sargs.objAttrs != nil {
+		res.Lsize = sargs.objAttrs.Lsize(true)
 	}
 	return res
 }


### PR DESCRIPTION
Summary
- Route remote-backend cold-read copies to another target through the existing per-object target PUT path instead of the long-lived data mover objstream.
- Retry remote cold-read transfers by reopening `GetROC` on retriable mid-stream failures such as `unexpected EOF`, short reads, connection resets, broken pipes, and timeouts.
- Keep normal in-cluster copies on the data mover path.
- Preserve copied byte accounting for reader-backed sends by returning the source object size after successful send/PUT.

Why
For copy-listrange from remote S3/MinIO into an AIS bucket, a remote reader can fail or close after the object header has already been sent over objstream. At that point the receiver is still waiting for the advertised object bytes, so the shared stream reports `sbr_obj_data_size` / `unexpected EOF` and the whole xaction can abort.

The fix keeps remote cold reads off the shared objstream and, importantly, retries the per-object transfer with a freshly opened backend reader when the source stream drops mid-object. That handles the backend-reader failure mode without changing the normal in-cluster DM path.

Testing
- `go test ./ais`
- `git diff --check`

Fixes #309