### PR TITLE
python: add read-only fsspec adapter

### DIFF
--- a/python/aistore/common_requirements
+++ b/python/aistore/common_requirements
@@ -17,6 +17,7 @@ pytest-xdist>=3.6.1
 typing-extensions>=4.12.2
 webdataset>=0.2.100
 tenacity>=9.0.0
+fsspec>=2024.2.0
 fastapi>=0.109.1
 httpx>=0.28.0
 aiofiles>=23.2.1

--- a/python/aistore/fsspec/README.md
+++ b/python/aistore/fsspec/README.md
@@ -1,0 +1,23 @@
+# AIStore fsspec Adapter
+
+The AIStore fsspec adapter provides read-only access to AIS objects through the
+standard fsspec filesystem interface.
+
+Install the optional dependency:
+
+```console
+pip install "aistore[fsspec]"
+```
+
+Use the adapter with an AIS endpoint:
+
+```python
+import fsspec
+
+fs = fsspec.filesystem("ais", endpoint="http://ais-proxy:8080")
+print(fs.ls("ais://dataset/prefix"))
+data = fs.cat("ais://dataset/object.bin")
+```
+
+The initial adapter supports object listing, metadata lookup, binary reads, and
+range reads. Mutating operations are intentionally unsupported.

--- a/python/aistore/fsspec/__init__.py
+++ b/python/aistore/fsspec/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+
+from aistore.fsspec.filesystem import AISFileSystem
+
+__all__ = ["AISFileSystem"]

--- a/python/aistore/fsspec/filesystem.py
+++ b/python/aistore/fsspec/filesystem.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+try:
+    from fsspec.spec import AbstractFileSystem
+except ImportError as err:  # pragma: no cover - exercised only when optional extra is missing
+    raise ImportError(
+        "AISFileSystem requires the optional fsspec dependency. "
+        "Install it with `pip install aistore[fsspec]`."
+    ) from err
+
+from aistore.sdk import Client
+from aistore.sdk.provider import Provider
+
+
+class AISFileSystem(AbstractFileSystem):
+    """
+    Read-only fsspec adapter for AIStore objects.
+
+    Paths are expected in the form ``ais://bucket/object`` or ``bucket/object``.
+    """
+
+    protocol = "ais"
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        provider: str = Provider.AIS.value,
+        client: Optional[Client] = None,
+        **client_kwargs: Any,
+    ):
+        super().__init__()
+        self._client = client or Client(endpoint, **client_kwargs)
+        self._provider = provider
+
+    @staticmethod
+    def _strip_protocol(path: str) -> str:
+        if path.startswith("ais://"):
+            return path[len("ais://") :]
+        return path
+
+    def _split_path(self, path: str) -> Tuple[str, str]:
+        clean_path = self._strip_protocol(path).lstrip("/")
+        if not clean_path:
+            raise ValueError("AIS path must include a bucket name")
+
+        bucket, _, object_name = clean_path.partition("/")
+        return bucket, object_name
+
+    def _bucket(self, bucket_name: str):
+        return self._client.bucket(bucket_name, provider=self._provider)
+
+    def ls(self, path: str, detail: bool = True, **kwargs: Any):
+        bucket_name, prefix = self._split_path(path)
+        entries = self._bucket(bucket_name).list_objects_iter(
+            prefix=prefix, props="name,size"
+        )
+
+        infos = [
+            {
+                "name": f"{bucket_name}/{entry.name}",
+                "size": entry.size,
+                "type": "file",
+            }
+            for entry in entries
+        ]
+        return infos if detail else [info["name"] for info in infos]
+
+    def info(self, path: str, **kwargs: Any) -> Dict[str, Any]:
+        bucket_name, object_name = self._split_path(path)
+        if not object_name:
+            return {
+                "name": bucket_name,
+                "size": 0,
+                "type": "directory",
+            }
+
+        props = self._bucket(bucket_name).object(object_name).props
+        return {
+            "name": f"{bucket_name}/{object_name}",
+            "size": props.size,
+            "type": "file",
+        }
+
+    def cat_file(
+        self,
+        path: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        **kwargs: Any,
+    ) -> bytes:
+        bucket_name, object_name = self._split_path(path)
+        if not object_name:
+            raise ValueError("AIS object path must include an object name")
+
+        byte_range = None
+        if start is not None or end is not None:
+            left = "" if start is None else str(start)
+            right = "" if end is None else str(end - 1)
+            byte_range = f"bytes={left}-{right}"
+
+        return (
+            self._bucket(bucket_name)
+            .object(object_name)
+            .get_reader(byte_range=byte_range)
+            .read_all()
+        )
+
+    def _open(
+        self,
+        path: str,
+        mode: str = "rb",
+        block_size: Optional[int] = None,
+        **kwargs: Any,
+    ):
+        if mode != "rb":
+            raise NotImplementedError(
+                "AIS fsspec adapter currently supports read-only binary mode"
+            )
+
+        bucket_name, object_name = self._split_path(path)
+        if not object_name:
+            raise ValueError("AIS object path must include an object name")
+
+        return self._bucket(bucket_name).object(object_name).get_reader().as_file()
+
+    def mkdir(self, path: str, create_parents: bool = True, **kwargs: Any) -> None:
+        raise NotImplementedError("AIS fsspec adapter does not create buckets")
+
+    def rm(
+        self, path: str, recursive: bool = False, maxdepth: Optional[int] = None
+    ) -> None:
+        raise NotImplementedError("AIS fsspec adapter is read-only")
+
+    def cp_file(self, path1: str, path2: str, **kwargs: Any) -> None:
+        raise NotImplementedError("AIS fsspec adapter is read-only")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -88,6 +88,12 @@ etl = [
 mcp = [
     "mcp[cli]>=1.4.1",
 ]
+fsspec = [
+    "fsspec>=2024.2.0",
+]
+
+[project.entry-points."fsspec.specs"]
+ais = "aistore.fsspec:AISFileSystem"
 
 [project.urls]
 "Homepage" = "https://aistore.nvidia.com"

--- a/python/tests/unit/fsspec/__init__.py
+++ b/python/tests/unit/fsspec/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#

--- a/python/tests/unit/fsspec/test_filesystem.py
+++ b/python/tests/unit/fsspec/test_filesystem.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+
+import unittest
+from unittest.mock import Mock
+
+from aistore.fsspec import AISFileSystem
+from aistore.sdk.types import BucketEntry
+
+
+class TestAISFileSystem(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = Mock()
+        self.bucket = self.client.bucket.return_value
+        self.fs = AISFileSystem(endpoint="http://ais.example", client=self.client)
+
+    def test_ls_returns_fsspec_file_info(self):
+        self.bucket.list_objects_iter.return_value = [
+            BucketEntry(n="data/a.csv", s=11),
+            BucketEntry(n="data/b.csv", s=13),
+        ]
+
+        result = self.fs.ls("ais://dataset/data")
+
+        self.client.bucket.assert_called_once_with("dataset", provider="ais")
+        self.bucket.list_objects_iter.assert_called_once_with(
+            prefix="data", props="name,size"
+        )
+        self.assertEqual(
+            [
+                {"name": "dataset/data/a.csv", "size": 11, "type": "file"},
+                {"name": "dataset/data/b.csv", "size": 13, "type": "file"},
+            ],
+            result,
+        )
+
+    def test_info_returns_object_size(self):
+        props = Mock(size=42)
+        self.bucket.object.return_value.props = props
+
+        result = self.fs.info("ais://dataset/data/a.csv")
+
+        self.bucket.object.assert_called_once_with("data/a.csv")
+        self.assertEqual(
+            {"name": "dataset/data/a.csv", "size": 42, "type": "file"}, result
+        )
+
+    def test_cat_file_uses_half_open_fsspec_range(self):
+        reader = Mock()
+        reader.read_all.return_value = b"bc"
+        self.bucket.object.return_value.get_reader.return_value = reader
+
+        result = self.fs.cat_file("ais://dataset/data/a.csv", start=1, end=3)
+
+        self.bucket.object.return_value.get_reader.assert_called_once_with(
+            byte_range="bytes=1-2"
+        )
+        self.assertEqual(b"bc", result)
+
+    def test_open_returns_sdk_file_reader(self):
+        file_reader = Mock()
+        self.bucket.object.return_value.get_reader.return_value.as_file.return_value = file_reader
+
+        result = self.fs.open("ais://dataset/data/a.csv", mode="rb")
+
+        self.assertEqual(file_reader, result)
+
+    def test_write_mode_is_not_supported(self):
+        with self.assertRaises(NotImplementedError):
+            self.fs.open("ais://dataset/data/a.csv", mode="wb")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- Add an optional aistore[fsspec] extra and fsspec entry point for ais:// paths.
- Implement a read-only AISFileSystem supporting object listing, metadata lookup, binary reads, range reads, and file-like opens through the existing Python SDK.
- Add focused unit coverage for listing, info, range reads, open(), and unsupported write mode.
- Document the minimal usage in the adapter package README.

Why
Issue #312 asks about client ecosystem expansion and integrations such as fsspec/OpenDAL. Instead of adding a broad roadmap document, this PR provides a small, reviewable fsspec integration that can validate whether this direction is useful before larger SDK/repository decisions.

Testing
- /private/tmp/aistore-fsspec-venv/bin/python -m pytest python/tests/unit/fsspec/test_filesystem.py -q
- /private/tmp/aistore-fsspec-venv/bin/python -m py_compile python/aistore/fsspec/filesystem.py python/tests/unit/fsspec/test_filesystem.py
- /private/tmp/aistore-fsspec-venv/bin/python - <<'PY'
import fsspec
from aistore.fsspec import AISFileSystem
fs = fsspec.filesystem('ais', endpoint='http://ais.example')
assert isinstance(fs, AISFileSystem)
print('fsspec entry point ok')
PY
- git diff --check

Addresses #312