### PR TITLE
copy: include backend context in remote read errors

### DIFF
--- a/ais/test/cp_multiobj_test.go
+++ b/ais/test/cp_multiobj_test.go
@@ -7,6 +7,7 @@ package integration_test
 import (
 	"fmt"
 	"math/rand/v2"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -105,6 +106,64 @@ func TestCopyMultiObj(t *testing.T) {
 	runProviderTests(t, func(t *testing.T, bck *meta.Bck) {
 		testCopyMobj(t, bck)
 	})
+}
+
+func TestCopyMultiObjRemoteReadErrorContext(t *testing.T) {
+	tools.CheckSkip(t, &tools.SkipTestArgs{RequiresRemoteCluster: true})
+
+	var (
+		proxyURL    = tools.RandomProxyURL(t)
+		baseParams  = tools.BaseAPIParams(proxyURL)
+		bckName     = "cp-remote-read-src-" + trand.String(8)
+		remoteBck   = cmn.Bck{Name: bckName, Provider: apc.AIS}
+		bckFrom     = cmn.Bck{Name: bckName, Provider: apc.AIS, Ns: cmn.Ns{UUID: tools.RemoteCluster.UUID}}
+		bckTo       = cmn.Bck{Name: "cp-remote-read-err-" + trand.String(8), Provider: apc.AIS}
+		objName     = "missing-remote-read-" + trand.String(16)
+		remoteProxy = tools.RemoteCluster.URL
+	)
+	tools.CreateBucket(t, remoteProxy, remoteBck, nil, true /*cleanup*/)
+	tools.CreateBucket(t, proxyURL, bckTo, nil, true /*cleanup*/)
+
+	msg := cmn.TCOMsg{
+		ToBck: bckTo,
+		TCOMsg: apc.TCOMsg{
+			ListRange: apc.ListRange{ObjNames: []string{objName}},
+		},
+	}
+	xid, err := api.CopyMultiObj(baseParams, bckFrom, &msg)
+	tassert.CheckFatal(t, err)
+
+	args := &xact.ArgsMsg{ID: xid, Kind: apc.ActCopyObjects, Bck: bckFrom, Timeout: time.Minute}
+	var errMsg string
+	finishedWithErr := func(snaps xact.MultiSnap) (done, reset bool, err error) {
+		for _, targetSnaps := range snaps {
+			for _, snap := range targetSnaps {
+				if snap.ID != xid {
+					continue
+				}
+				switch {
+				case snap.AbortErr != "":
+					errMsg = snap.AbortErr
+				case snap.Err != "":
+					errMsg = snap.Err
+				}
+				if errMsg != "" {
+					return true, false, nil
+				}
+				if snap.IsFinished() || snap.IsAborted() {
+					return true, false, nil
+				}
+			}
+		}
+		return false, false, nil
+	}
+	_, err = api.WaitForSnaps(baseParams, args, finishedWithErr)
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, errMsg != "", "expected copy error for missing remote object")
+
+	for _, want := range []string{"remote backend", bckFrom.Provider, "GetObjReader", bckName, objName} {
+		tassert.Fatalf(t, strings.Contains(errMsg, want), "expected %q in error %q", want, errMsg)
+	}
 }
 
 func testCopyMobj(t *testing.T, bck *meta.Bck) {

--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -1781,7 +1781,10 @@ func (coi *coi) do(t *target, dm *bundle.DM, lom *core.LOM) (res xs.CoiRes) {
 			coi.ETLArgs.Pipeline = make(apc.ETLPipeline, 0, 1)
 		}
 		coi.ETLArgs.Pipeline.Join(daddr.String()) // attach direct put destination target to the pipeline
-		var r cos.ReadOpenCloser
+		var (
+			r      cos.ReadOpenCloser
+			remote bool
+		)
 		if coi.PutWOC != nil {
 			_, ecode, err := coi.PutWOC(lom, coi.LatestVer, coi.Sync, nil, coi.ETLArgs)
 			return xs.CoiRes{Err: err, Ecode: ecode}
@@ -1789,12 +1792,15 @@ func (coi *coi) do(t *target, dm *bundle.DM, lom *core.LOM) (res xs.CoiRes) {
 			resp := coi.GetROC(lom, coi.LatestVer, coi.Sync, coi.ETLArgs)
 			// skip t2t send if encounter error during GetROC, (etl direct put will return ErrSkip in this case)
 			if resp.Err != nil {
-				return xs.CoiRes{Err: resp.Err, Ecode: resp.Ecode}
+				return xs.CoiRes{Err: resp.Err, Ecode: resp.Ecode, RGET: resp.Remote}
 			}
 			coi.OAH = resp.OAH
 			r = resp.R
+			remote = resp.Remote
 		}
-		return coi.send(t, dm, lom, r, tsi) // lom is the source of reader if no reader specified
+		res := coi.send(t, dm, lom, r, tsi) // lom is the source of reader if no reader specified
+		res.RGET = remote
+		return res
 	}
 
 	// dst is this target
@@ -1924,7 +1930,7 @@ func (coi *coi) _reader(t *target, dm *bundle.DM, lom, dst *core.LOM, args *core
 	debug.Assertf(coi.GetROC != nil, "coi.GetROC is nil in _reader, object name: %s", coi.ObjnameTo)
 	resp := coi.GetROC(lom, coi.LatestVer, coi.Sync, args)
 	if resp.Err != nil {
-		return xs.CoiRes{Ecode: resp.Ecode, Err: resp.Err}
+		return xs.CoiRes{Ecode: resp.Ecode, Err: resp.Err, RGET: resp.Remote}
 	}
 	poi := allocPOI()
 	defer freePOI(poi)
@@ -1951,9 +1957,10 @@ func (coi *coi) _reader(t *target, dm *bundle.DM, lom, dst *core.LOM, args *core
 
 	ecode, err := poi.putObject()
 	if err != nil {
-		return xs.CoiRes{Ecode: ecode, Err: err}
+		return xs.CoiRes{Ecode: ecode, Err: err, RGET: resp.Remote}
 	}
 	res.Lsize = poi.lom.Lsize()
+	res.RGET = resp.Remote
 
 	return res
 }

--- a/ais/tgtobj_internal_test.go
+++ b/ais/tgtobj_internal_test.go
@@ -40,6 +40,9 @@ type (
 	discardRW struct {
 		w io.Writer
 	}
+	failingTestROC struct {
+		err error
+	}
 )
 
 func newDiscardRW() *discardRW {
@@ -51,6 +54,12 @@ func newDiscardRW() *discardRW {
 func (drw *discardRW) Write(p []byte) (int, error) { return drw.w.Write(p) }
 func (*discardRW) Header() http.Header             { return make(http.Header) }
 func (*discardRW) WriteHeader(int)                 {}
+
+func (r *failingTestROC) Read([]byte) (int, error) { return 0, r.err }
+func (*failingTestROC) Close() error               { return nil }
+func (r *failingTestROC) Open() (cos.ReadOpenCloser, error) {
+	return &failingTestROC{err: r.err}, nil
+}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/core/ldp.go
+++ b/core/ldp.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -123,10 +124,23 @@ func (lom *LOM) GetROC(latestVer, sync bool) (resp ReadResp) {
 remote:
 	// GetObjReader and return remote (object) reader and oah for object metadata
 	// (compare w/ T.GetCold)
-	res := T.Backend(bck).GetObjReader(context.Background(), lom, 0, 0)
+	backend := T.Backend(bck)
+	bucket := bck.String()
+	if remoteBck := bck.RemoteBck(); remoteBck != nil {
+		bucket = remoteBck.String()
+	}
+	res := backend.GetObjReader(context.Background(), lom, 0, 0)
+	resp.Remote = true
 
 	if res.Err != nil {
-		resp.Err, resp.Ecode = res.Err, res.ErrCode
+		if res.ErrCode != 0 {
+			resp.Err = fmt.Errorf("remote backend %s GetObjReader failed for %s/%s (status=%d): %w",
+				backend.Provider(), bucket, lom.ObjName, res.ErrCode, res.Err)
+		} else {
+			resp.Err = fmt.Errorf("remote backend %s GetObjReader failed for %s/%s: %w",
+				backend.Provider(), bucket, lom.ObjName, res.Err)
+		}
+		resp.Ecode = res.ErrCode
 		return resp
 	}
 
@@ -137,8 +151,6 @@ remote:
 		Size:     res.Size,
 	}
 	resp.OAH = oah
-	resp.Remote = true
-
 	// [NOTE] ref 6079834
 	// non-trivial limitation: this reader cannot be transmitted to
 	// multiple targets (where we actually rely on real re-opening);

--- a/xact/xs/coi.go
+++ b/xact/xs/coi.go
@@ -147,20 +147,21 @@ func (tc *copier) do(a *CoiParams, lom *core.LOM, dm *bundle.DM) (err error) {
 		err = res.Err
 		tc.r.Abort(err)
 	default:
+		opErr := res.Err
 		if cmn.Rom.V(5, cos.ModXs) {
-			nlog.Warningln(tc.r.Name(), lom.Cname(), res.Err)
+			nlog.Warningln(tc.r.Name(), lom.Cname(), opErr)
 		}
 		if tc.xetl != nil {
 			tc.xetl.AddObjErr(tc.r.ID(), &etl.ObjErr{
 				ObjName: lom.Cname(),
-				Message: res.Err.Error(),
+				Message: opErr.Error(),
 				Ecode:   res.Ecode,
 			})
 		}
 		if contOnErr {
-			tc.r.AddErr(res.Err, 5, cos.ModXs)
+			tc.r.AddErr(opErr, 5, cos.ModXs)
 		} else {
-			err = res.Err
+			err = opErr
 			tc.r.Abort(err)
 		}
 	}


### PR DESCRIPTION
Summary

- Remove the previous `RemoteSource` / `RemoteSourceError` plumbing and keep the patch minimal.
- Wrap `GetObjReader` failures at the remote-backend boundary with backend/provider, remote bucket/object, operation, status code when available, and the original cause via `%w`.
- Return that wrapped error through the existing copy/ETL path without adding copy-result context or changing reader behavior.
- Keep copy transport/retry behavior unchanged; `RGET` remains only for stats.
- Add live-cluster integration coverage for copy-listrange on a remote bucket missing source object, asserting the xaction error includes backend/provider and remote object context.

Why

This reworks #321 based on maintainer feedback. The patch now only adds essential remote-backend context at the actual `GetObjReader` failure point, avoiding new diagnostic structs and avoiding reader wrappers or broader result-path plumbing.

Refs #309.

Testing

- `GOCACHE=/private/tmp/aistore-backend-gocache GOMODCACHE=/private/tmp/aistore-backend-gomodcache go test ./core -run '^$'`
- `GOCACHE=/private/tmp/aistore-backend-gocache GOMODCACHE=/private/tmp/aistore-backend-gomodcache go test ./xact/xs -run '^$'`
- `GOCACHE=/private/tmp/aistore-backend-gocache GOMODCACHE=/private/tmp/aistore-backend-gomodcache go test ./ais -run '^$'`
- `GOCACHE=/private/tmp/aistore-backend-gocache GOMODCACHE=/private/tmp/aistore-backend-gomodcache go test -c ./ais/test -o /private/tmp/aistore-ais-test.test`
- `git diff --check`

Not fully run locally:

- `go test ./ais/test -run TestCopyMultiObjRemoteReadErrorContext` requires a live AIS cluster with a configured remote bucket. In this local environment, the integration package attempts to reach `http://localhost:8080` and fails with connection refused.