### PR TITLE
docs: fix GET error rate query

### DIFF
--- a/docs/monitoring-grafana.md
+++ b/docs/monitoring-grafana.md
@@ -278,8 +278,9 @@ Set up alerts based on the AIStore node state flags (refer to [Node Alerts in AI
    - Description: "GET operation latency exceeds 200ms"
 
 2. Error rate alert:
-   - Condition: `sum(rate(ais_target_err_get_count[5m])) / sum(rate(ais_target_get_count[5m])) * 100 > 1`
+   - Condition: `sum(rate(ais_target_err_get_count[5m])) / (sum(rate(ais_target_get_count[5m])) + sum(rate(ais_target_err_get_count[5m]))) * 100 > 1`
    - Description: "GET error rate exceeds 1%"
+   - Note: `ais_target_get_count` tracks successful GETs. Object-not-found GETs are counted in `ais_target_err_get_count` only when the `Count-Object-NotFound-Stats` feature flag is enabled.
 
 ### Resource Alerts
 

--- a/docs/monitoring-prometheus.md
+++ b/docs/monitoring-prometheus.md
@@ -205,8 +205,13 @@ ais_target_disk_util{disk="nvme0n1"}
 
 ```promql
 sum(rate(ais_target_err_get_count[5m]))
-/ sum(rate(ais_target_get_count[5m])) * 100
+/ (
+    sum(rate(ais_target_get_count[5m]))
+    + sum(rate(ais_target_err_get_count[5m]))
+  ) * 100
 ```
+
+`ais_target_get_count` tracks successful GETs, so include `ais_target_err_get_count` in the denominator when calculating an error percentage. Object-not-found GETs are counted in `ais_target_err_get_count` only when the `Count-Object-NotFound-Stats` feature flag is enabled.
 
 ### Total cluster capacity usage
 
@@ -365,4 +370,3 @@ Separately, Prometheus references:
 * [Prometheus Exporters](https://prometheus.io/docs/instrumenting/writing_exporters/)
 * [Prometheus Data Model](https://prometheus.io/docs/concepts/data_model/)
 * [Prometheus Metric Types](https://prometheus.io/docs/concepts/metric_types/)
-


### PR DESCRIPTION
## Summary
- update the GET error percentage query to divide errors by successful plus failed GETs
- add the same denominator to the Grafana alert example
- document the `Count-Object-NotFound-Stats` caveat for object-not-found GETs

## Testing
- `git diff --check`
- checked monitoring docs for the updated query and feature-flag note

Fixes #322