### PR TITLE
object: add target-side CSV select MVP

### DIFF
--- a/ais/proxy.go
+++ b/ais/proxy.go
@@ -2041,7 +2041,7 @@ func (p *proxy) httpobjpost(w http.ResponseWriter, r *http.Request, apireq *apiR
 		return
 	}
 	switch msg.Action {
-	case apc.ActRenameObject, apc.ActCheckLock, apc.ActMptUpload, apc.ActMptAbort, apc.ActMptComplete:
+	case apc.ActRenameObject, apc.ActSelectObject, apc.ActCheckLock, apc.ActMptUpload, apc.ActMptAbort, apc.ActMptComplete:
 		apireq.after = 2
 	}
 	if err := p.parseReq(w, r, apireq); err != nil {
@@ -2135,6 +2135,11 @@ func (p *proxy) httpobjpost(w http.ResponseWriter, r *http.Request, apireq *apiR
 		}
 		objName := msg.Name
 		p.redirectAction(w, r, bck, objName, msg)
+	case apc.ActSelectObject:
+		if err := p.checkAccess(w, r, bck, apc.AccessRO); err != nil {
+			return
+		}
+		p.redirectAction(w, r, bck, apireq.items[1], msg)
 	case apc.ActMptUpload, apc.ActMptAbort, apc.ActMptComplete:
 		if err := p.checkAccess(w, r, bck, apc.AccessRW); err != nil {
 			return

--- a/ais/target.go
+++ b/ais/target.go
@@ -1242,6 +1242,19 @@ func (t *target) httpobjpost(w http.ResponseWriter, r *http.Request, apireq *api
 			vlabs := map[string]string{stats.VlabBucket: lom.Bck().Cname("")}
 			t.statsT.IncWith(stats.ErrRenameCount, vlabs)
 		}
+	case apc.ActSelectObject:
+		var (
+			selectMsg cmn.SelectObjectMsg
+			lom       = &core.LOM{ObjName: apireq.items[1]}
+		)
+		if err = lom.InitBck(apireq.bck); err != nil {
+			break
+		}
+		if err = cos.MorphMarshal(msg.Value, &selectMsg); err != nil {
+			err = fmt.Errorf(cmn.FmtErrMorphUnmarshal, t, msg.Action, msg.Value, err)
+			break
+		}
+		ecode, err = t.objSelect(w, r, lom, &selectMsg)
 	case apc.ActBlobDl:
 		var (
 			xid     string

--- a/ais/tgtobj_internal_test.go
+++ b/ais/tgtobj_internal_test.go
@@ -8,8 +8,10 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,6 +176,44 @@ func TestPutObjectChunks(tst *testing.T) {
 			actualChunks := manifest.Count()
 			tassert.Fatalf(test, actualChunks == tt.expectedParts, "chunk count mismatch: expected %d parts, got %d", tt.expectedParts, actualChunks)
 		})
+	}
+}
+
+func TestObjSelectRunsOnTarget(tst *testing.T) {
+	const (
+		objName = "select.csv"
+		csvBody = "name,kind,score\nalpha,a,7\nbeta,b,12\ngamma,b,3\n"
+	)
+	lom := core.AllocLOM(objName)
+	defer core.FreeLOM(lom)
+	err := lom.InitBck(&meta.Bck{Name: testBucket, Provider: apc.AIS, Ns: cmn.NsGlobal})
+	tassert.CheckFatal(tst, err)
+	defer lom.RemoveMain()
+
+	poi := &putOI{
+		atime:   time.Now().UnixNano(),
+		t:       t,
+		lom:     lom,
+		r:       io.NopCloser(strings.NewReader(csvBody)),
+		oreq:    &http.Request{Header: make(http.Header)},
+		workFQN: path.Join(testMountpath, "select.csv.work"),
+		config:  cmn.GCO.Get(),
+		size:    int64(len(csvBody)),
+	}
+	_, err = poi.putObject()
+	tassert.CheckFatal(tst, err)
+
+	rec := httptest.NewRecorder()
+	ecode, err := t.objSelect(rec, nil, lom, &cmn.SelectObjectMsg{Query: "SELECT name,score WHERE score > 10"})
+	tassert.CheckFatal(tst, err)
+	tassert.Fatalf(tst, ecode == 0, "unexpected status code: %d", ecode)
+
+	const expected = "name,score\nbeta,12\n"
+	if got := rec.Body.String(); got != expected {
+		tst.Fatalf("unexpected select output:\nexpected: %q\ngot:      %q", expected, got)
+	}
+	if ctype := rec.Header().Get(cos.HdrContentType); ctype != "text/csv" {
+		tst.Fatalf("unexpected content type: %q", ctype)
 	}
 }
 

--- a/ais/tgtobj_select.go
+++ b/ais/tgtobj_select.go
@@ -1,0 +1,31 @@
+// Package ais provides AIStore's proxy and target nodes.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package ais
+
+import (
+	"net/http"
+
+	"github.com/NVIDIA/aistore/cmn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/core"
+)
+
+func (t *target) objSelect(w http.ResponseWriter, _ *http.Request, lom *core.LOM, msg *cmn.SelectObjectMsg) (int, error) {
+	if err := msg.Validate(); err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	resp := lom.GetROC(false /*latestVer*/, false /*sync*/)
+	if resp.Err != nil {
+		return resp.Ecode, resp.Err
+	}
+	defer resp.R.Close()
+
+	w.Header().Set(cos.HdrContentType, "text/csv")
+	if err := cmn.SelectObject(resp.R, w, msg); err != nil {
+		return http.StatusBadRequest, err
+	}
+	return 0, nil
+}

--- a/api/apc/actmsg.go
+++ b/api/apc/actmsg.go
@@ -60,6 +60,7 @@ const (
 	ActNewPrimary     = "new-primary"
 	ActPromote        = "promote"
 	ActRenameObject   = "rename-obj"
+	ActSelectObject   = "select-obj"
 
 	// multipart upload
 	ActMptUpload   = "mpt-upload"   // create a new multipart upload

--- a/api/object.go
+++ b/api/object.go
@@ -283,6 +283,26 @@ func GetObjectReader(bp BaseParams, bck cmn.Bck, objName string, args *GetArgs) 
 	return
 }
 
+// SelectObjectReader returns server-side object-select output as a response stream.
+// The target that owns the object reads the source object and applies the selection.
+func SelectObjectReader(bp BaseParams, bck cmn.Bck, objName string, msg *cmn.SelectObjectMsg) (r io.ReadCloser, size int64, err error) {
+	q := qalloc()
+	bp.Method = http.MethodPost
+	reqParams := AllocRp()
+	{
+		reqParams.BaseParams = bp
+		reqParams.Path = apc.URLPathObjects.Join(bck.Name, objName)
+		reqParams.Body = cos.MustMarshal(apc.ActMsg{Action: apc.ActSelectObject, Value: msg})
+		reqParams.Header = http.Header{cos.HdrContentType: []string{cos.ContentJSON}}
+		bck.SetQuery(q)
+		reqParams.Query = q
+	}
+	r, size, err = reqParams.doReader()
+	FreeRp(reqParams)
+	qfree(q)
+	return
+}
+
 // PUT(object) ============================================================================================
 //
 // Uses the specified reader (`args.Reader`) to write a new object (or a new version of the object).

--- a/cmd/cli/cli/const.go
+++ b/cmd/cli/cli/const.go
@@ -69,6 +69,7 @@ const (
 	commandPut       = "put"
 	commandRemove    = "rm"
 	commandRename    = "mv"
+	commandSelect    = "select"
 	commandSet       = "set"
 
 	// multipart upload commands
@@ -363,7 +364,8 @@ const (
 	mptCompleteArgument = objectArgument + " UPLOAD_ID PART_NUMBERS"
 	mptAbortArgument    = objectArgument + " UPLOAD_ID"
 
-	getObjectArgument = "BUCKET[/OBJECT_NAME] [OUT_FILE|OUT_DIR|-]"
+	getObjectArgument    = "BUCKET[/OBJECT_NAME] [OUT_FILE|OUT_DIR|-]"
+	selectObjectArgument = objectArgument + " --query QUERY"
 
 	optionalPrefixArgument = "BUCKET[/OBJECT_NAME_or_PREFIX]"
 	putObjectArgument      = "[-|FILE|DIRECTORY[/PATTERN]] " + optionalPrefixArgument

--- a/cmd/cli/cli/object_hdlr.go
+++ b/cmd/cli/cli/object_hdlr.go
@@ -204,6 +204,12 @@ var (
 			forceFlag,
 			encodeObjnameFlag,
 		},
+		commandSelect: {
+			objectSelectQueryFlag,
+			objectSelectInputFormatFlag,
+			objectSelectOutputFormatFlag,
+			encodeObjnameFlag,
+		},
 		cmdMptCreate: {
 			verboseFlag,
 		},
@@ -331,6 +337,14 @@ var (
 				ArgsUsage:    objectArgument,
 				Flags:        sortFlags(objectCmdsFlags[commandCat]),
 				Action:       catHandler,
+				BashComplete: bucketCompletions(bcmplop{separator: true}),
+			},
+			{
+				Name:         commandSelect,
+				Usage:        "Select rows and columns from a structured object on the target",
+				ArgsUsage:    selectObjectArgument,
+				Flags:        sortFlags(objectCmdsFlags[commandSelect]),
+				Action:       objectSelectHandler,
 				BashComplete: bucketCompletions(bcmplop{separator: true}),
 			},
 			// multipart upload commands

--- a/cmd/cli/cli/object_select.go
+++ b/cmd/cli/cli/object_select.go
@@ -1,0 +1,135 @@
+// Package cli provides easy-to-use commands to manage, monitor, and utilize AIS clusters.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/NVIDIA/aistore/api"
+	"github.com/NVIDIA/aistore/api/apc"
+	"github.com/NVIDIA/aistore/cmn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+
+	"github.com/urfave/cli"
+)
+
+const (
+	// Keep in sync with apc.ActSelectObject. The CLI module can be built against
+	// the previous root-module version before the next AIS module bump.
+	objectSelectAction    = "select-obj"
+	objectSelectFormatCSV = "csv"
+)
+
+type objectSelectMsg struct {
+	Query        string `json:"query"`
+	InputFormat  string `json:"input_format"`
+	OutputFormat string `json:"output_format"`
+}
+
+var (
+	objectSelectQueryFlag = cli.StringFlag{
+		Name:  "query,q",
+		Usage: "SQL-like projection and filter expression, e.g. \"SELECT col1,col2 WHERE col3 > 10\"",
+	}
+	objectSelectInputFormatFlag = cli.StringFlag{
+		Name:  "input-format",
+		Value: objectSelectFormatCSV,
+		Usage: "Input object format; currently supported: csv",
+	}
+	objectSelectOutputFormatFlag = cli.StringFlag{
+		Name:  "output-format",
+		Value: objectSelectFormatCSV,
+		Usage: "Output format; currently supported: csv",
+	}
+)
+
+func objectSelectHandler(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return missingArgumentsError(c, c.Command.ArgsUsage)
+	}
+
+	msg := &objectSelectMsg{
+		Query:        parseStrFlag(c, objectSelectQueryFlag),
+		InputFormat:  parseStrFlag(c, objectSelectInputFormatFlag),
+		OutputFormat: parseStrFlag(c, objectSelectOutputFormatFlag),
+	}
+	if msg.Query == "" {
+		return missingArgumentsError(c, flprn(objectSelectQueryFlag))
+	}
+	if err := msg.validate(); err != nil {
+		return err
+	}
+
+	bck, objName, err := parseBckObjURI(c, c.Args().Get(0), false)
+	if err != nil {
+		return err
+	}
+	if objName == "" {
+		return missingArgumentsError(c, "object name in the form "+objectArgument)
+	}
+
+	var warned bool
+	encObjName := warnEscapeObjName(c, objName, &warned)
+	reader, err := selectObjectReader(bck, encObjName, msg)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	_, err = io.Copy(c.App.Writer, reader)
+	return err
+}
+
+func (msg *objectSelectMsg) validate() error {
+	msg.InputFormat = strings.ToLower(msg.InputFormat)
+	msg.OutputFormat = strings.ToLower(msg.OutputFormat)
+	if msg.InputFormat == "" {
+		msg.InputFormat = objectSelectFormatCSV
+	}
+	if msg.OutputFormat == "" {
+		msg.OutputFormat = objectSelectFormatCSV
+	}
+	if msg.InputFormat != objectSelectFormatCSV {
+		return fmt.Errorf("unsupported %s=%q: currently supported format is %q",
+			flprn(objectSelectInputFormatFlag), msg.InputFormat, objectSelectFormatCSV)
+	}
+	if msg.OutputFormat != objectSelectFormatCSV {
+		return fmt.Errorf("unsupported %s=%q: currently supported format is %q",
+			flprn(objectSelectOutputFormatFlag), msg.OutputFormat, objectSelectFormatCSV)
+	}
+	return nil
+}
+
+func selectObjectReader(bck cmn.Bck, objName string, msg *objectSelectMsg) (io.ReadCloser, error) {
+	q := make(url.Values, 2)
+	bck.SetQuery(q)
+	reqArgs := cmn.HreqArgs{
+		Method: http.MethodPost,
+		Base:   apiBP.URL,
+		Path:   apc.URLPathObjects.Join(bck.Name, objName),
+		Query:  q,
+		Body:   cos.MustMarshal(apc.ActMsg{Action: objectSelectAction, Value: msg}),
+		Header: http.Header{cos.HdrContentType: []string{cos.ContentJSON}},
+	}
+	req, err := reqArgs.ReqDeprecated()
+	if err != nil {
+		return nil, err
+	}
+	api.SetAuxHeaders(req, &apiBP)
+
+	resp, err := apiBP.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := cmn.CheckResp(resp, http.MethodPost, req.URL.Path); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/cmn/obj_select.go
+++ b/cmn/obj_select.go
@@ -1,0 +1,262 @@
+// Package cmn provides common constants, types, and utilities for AIS clients
+// and AIStore.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cmn
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const SelectObjectFormatCSV = "csv"
+
+type (
+	SelectObjectMsg struct {
+		Query        string `json:"query"`
+		InputFormat  string `json:"input_format"`
+		OutputFormat string `json:"output_format"`
+	}
+
+	selectObjectQuery struct {
+		columns   []string
+		predicate *selectObjectPredicate
+	}
+
+	selectObjectPredicate struct {
+		column string
+		op     string
+		value  string
+	}
+)
+
+func (msg *SelectObjectMsg) Normalize() {
+	if msg.InputFormat == "" {
+		msg.InputFormat = SelectObjectFormatCSV
+	}
+	if msg.OutputFormat == "" {
+		msg.OutputFormat = SelectObjectFormatCSV
+	}
+	msg.InputFormat = strings.ToLower(msg.InputFormat)
+	msg.OutputFormat = strings.ToLower(msg.OutputFormat)
+}
+
+func (msg *SelectObjectMsg) Validate() error {
+	msg.Normalize()
+	if msg.Query == "" {
+		return fmt.Errorf("select query is required")
+	}
+	if msg.InputFormat != SelectObjectFormatCSV {
+		return fmt.Errorf("unsupported input format %q: currently supported format is %q", msg.InputFormat, SelectObjectFormatCSV)
+	}
+	if msg.OutputFormat != SelectObjectFormatCSV {
+		return fmt.Errorf("unsupported output format %q: currently supported format is %q", msg.OutputFormat, SelectObjectFormatCSV)
+	}
+	_, err := parseSelectObjectQuery(msg.Query)
+	return err
+}
+
+func SelectObject(in io.Reader, out io.Writer, msg *SelectObjectMsg) error {
+	if err := msg.Validate(); err != nil {
+		return err
+	}
+	return selectCSVObject(in, out, msg.Query)
+}
+
+func parseSelectObjectQuery(query string) (*selectObjectQuery, error) {
+	const selectKeyword = "select "
+	trimmed := strings.TrimSpace(query)
+	if len(trimmed) < len(selectKeyword) || !strings.EqualFold(trimmed[:len(selectKeyword)], selectKeyword) {
+		return nil, fmt.Errorf("query must start with SELECT")
+	}
+
+	body := strings.TrimSpace(trimmed[len(selectKeyword):])
+	if body == "" {
+		return nil, fmt.Errorf("missing SELECT projection")
+	}
+
+	whereIdx := indexSelectKeyword(body, "where")
+	projection := body
+	var where string
+	if whereIdx >= 0 {
+		projection = strings.TrimSpace(body[:whereIdx])
+		where = strings.TrimSpace(body[whereIdx+len("where"):])
+	}
+	if fromIdx := indexSelectKeyword(projection, "from"); fromIdx >= 0 {
+		projection = strings.TrimSpace(projection[:fromIdx])
+	}
+	if projection == "" {
+		return nil, fmt.Errorf("missing SELECT projection")
+	}
+
+	parsed := &selectObjectQuery{}
+	if projection == "*" {
+		parsed.columns = []string{"*"}
+	} else {
+		cols := strings.Split(projection, ",")
+		for _, col := range cols {
+			col = strings.TrimSpace(col)
+			if col == "" {
+				return nil, fmt.Errorf("empty projection column in %q", projection)
+			}
+			parsed.columns = append(parsed.columns, col)
+		}
+	}
+
+	if where != "" {
+		predicate, err := parseSelectObjectPredicate(where)
+		if err != nil {
+			return nil, err
+		}
+		parsed.predicate = predicate
+	}
+	return parsed, nil
+}
+
+func parseSelectObjectPredicate(where string) (*selectObjectPredicate, error) {
+	for _, op := range []string{">=", "<=", "!=", "=", ">", "<"} {
+		if idx := strings.Index(where, op); idx >= 0 {
+			column := strings.TrimSpace(where[:idx])
+			value := strings.TrimSpace(where[idx+len(op):])
+			if column == "" || value == "" {
+				return nil, fmt.Errorf("invalid WHERE predicate %q", where)
+			}
+			value = strings.Trim(value, `"'`)
+			return &selectObjectPredicate{column: column, op: op, value: value}, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported WHERE predicate %q", where)
+}
+
+func indexSelectKeyword(s, keyword string) int {
+	fields := strings.Fields(s)
+	offset := 0
+	for _, field := range fields {
+		idx := strings.Index(s[offset:], field)
+		if idx < 0 {
+			continue
+		}
+		offset += idx
+		if strings.EqualFold(field, keyword) {
+			return offset
+		}
+		offset += len(field)
+	}
+	return -1
+}
+
+func selectCSVObject(in io.Reader, out io.Writer, query string) error {
+	parsed, err := parseSelectObjectQuery(query)
+	if err != nil {
+		return err
+	}
+
+	reader := csv.NewReader(in)
+	reader.FieldsPerRecord = -1
+	header, err := reader.Read()
+	if err != nil {
+		return err
+	}
+	index := make(map[string]int, len(header))
+	for i, col := range header {
+		index[col] = i
+	}
+
+	projection, err := selectProjectionIndexes(header, index, parsed.columns)
+	if err != nil {
+		return err
+	}
+	predicateIndex := -1
+	if parsed.predicate != nil {
+		var ok bool
+		predicateIndex, ok = index[parsed.predicate.column]
+		if !ok {
+			return fmt.Errorf("unknown WHERE column %q", parsed.predicate.column)
+		}
+	}
+
+	writer := csv.NewWriter(out)
+	if err := writer.Write(selectProjectRecord(header, projection)); err != nil {
+		return err
+	}
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if parsed.predicate != nil {
+			if predicateIndex >= len(record) || !matchSelectPredicate(record[predicateIndex], parsed.predicate) {
+				continue
+			}
+		}
+		if err := writer.Write(selectProjectRecord(record, projection)); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func selectProjectionIndexes(header []string, index map[string]int, columns []string) ([]int, error) {
+	if len(columns) == 1 && columns[0] == "*" {
+		out := make([]int, len(header))
+		for i := range header {
+			out[i] = i
+		}
+		return out, nil
+	}
+
+	out := make([]int, 0, len(columns))
+	for _, col := range columns {
+		idx, ok := index[col]
+		if !ok {
+			return nil, fmt.Errorf("unknown SELECT column %q", col)
+		}
+		out = append(out, idx)
+	}
+	return out, nil
+}
+
+func selectProjectRecord(record []string, projection []int) []string {
+	out := make([]string, len(projection))
+	for i, idx := range projection {
+		if idx < len(record) {
+			out[i] = record[idx]
+		}
+	}
+	return out
+}
+
+func matchSelectPredicate(got string, predicate *selectObjectPredicate) bool {
+	switch predicate.op {
+	case "=":
+		return got == predicate.value
+	case "!=":
+		return got != predicate.value
+	}
+
+	left, lerr := strconv.ParseFloat(got, 64)
+	right, rerr := strconv.ParseFloat(predicate.value, 64)
+	if lerr != nil || rerr != nil {
+		return false
+	}
+	switch predicate.op {
+	case ">":
+		return left > right
+	case "<":
+		return left < right
+	case ">=":
+		return left >= right
+	case "<=":
+		return left <= right
+	default:
+		return false
+	}
+}

--- a/cmn/obj_select_test.go
+++ b/cmn/obj_select_test.go
@@ -1,0 +1,68 @@
+// Package cmn provides common constants, types, and utilities for AIS clients
+// and AIStore.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cmn
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectObjectCSVProjectionAndPredicate(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\nbeta,b,12\ngamma,b,3\n")
+	var output strings.Builder
+
+	err := SelectObject(input, &output, &SelectObjectMsg{Query: "SELECT name,score WHERE score > 10"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expected = "name,score\nbeta,12\n"
+	if got := output.String(); got != expected {
+		t.Fatalf("unexpected output:\nexpected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestSelectObjectCSVSelectAllWithStringPredicate(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\nbeta,b,12\ngamma,b,3\n")
+	var output strings.Builder
+
+	err := SelectObject(input, &output, &SelectObjectMsg{Query: `SELECT * WHERE kind = "b"`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expected = "name,kind,score\nbeta,b,12\ngamma,b,3\n"
+	if got := output.String(); got != expected {
+		t.Fatalf("unexpected output:\nexpected:\n%q\ngot:\n%q", expected, got)
+	}
+}
+
+func TestSelectObjectRejectsUnknownColumn(t *testing.T) {
+	input := strings.NewReader("name,kind,score\nalpha,a,7\n")
+	var output strings.Builder
+
+	err := SelectObject(input, &output, &SelectObjectMsg{Query: "SELECT missing WHERE score > 10"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `unknown SELECT column "missing"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSelectObjectQueryAllowsFromClause(t *testing.T) {
+	parsed, err := parseSelectObjectQuery("SELECT name, score FROM object WHERE score >= 10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.columns) != 2 || parsed.columns[0] != "name" || parsed.columns[1] != "score" {
+		t.Fatalf("unexpected columns: %#v", parsed.columns)
+	}
+	if parsed.predicate == nil || parsed.predicate.column != "score" ||
+		parsed.predicate.op != ">=" || parsed.predicate.value != "10" {
+		t.Fatalf("unexpected predicate: %#v", parsed.predicate)
+	}
+}


### PR DESCRIPTION
Summary
- Add `ais object select` as a limited CSV MVP that routes through AIS instead of filtering locally in the CLI.
- Add a `select-obj` object POST action; the proxy redirects to the owning target, and the target reads the source object via `LOM.GetROC` and streams selected CSV rows.
- Add `api.SelectObjectReader` for callers that want the server-side object-select response stream.
- Keep the first scope narrow: CSV input/output, `SELECT` projection, `SELECT *`, optional `FROM`, and simple string/numeric `WHERE` predicates.
- Add shared selector coverage plus a target-side regression that stores a CSV object and exercises the target selection path.

Why
This replaces the closed client-side prototype in #310 with the server/target-side MVP requested in review. The CLI no longer performs a normal full-object GET and filters locally; it POSTs an object action to AIS, and the target performs the read/filter/stream path.

Scope / non-goals
- No S3 Select compatibility yet.
- No Parquet/JSON/DuckDB integration yet.
- No predicate pushdown into remote backend format readers yet.
- This is a stage-one CSV path intended to make the API, proxy routing, target execution, and streaming response shape reviewable.

Testing
- `GOCACHE=/private/tmp/aistore-select-gocache GOMODCACHE=/private/tmp/aistore-select-gomodcache go test ./cmn`
- `GOCACHE=/private/tmp/aistore-select-gocache GOMODCACHE=/private/tmp/aistore-select-gomodcache go test ./api`
- `GOCACHE=/private/tmp/aistore-select-gocache GOMODCACHE=/private/tmp/aistore-select-gomodcache go test ./ais -run TestObjSelectRunsOnTarget`
- `cd cmd/cli && GOCACHE=/private/tmp/aistore-select-gocache GOMODCACHE=/private/tmp/aistore-select-gomodcache go test ./cli`
- `git diff --check`

Replaces the closed client-side prototype #310.
Refs #305.