### PR TITLE
docs: organize Fern navigation by standard IA

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -8,109 +8,82 @@ redirect_from:
  - /docs/docs.md/
 ---
 
-AIStore documentation is organized by task: getting started, accessing AIS via CLI/API/SDK, managing storage and clusters, deploying in production, and exploring advanced features.
+AIStore documentation is organized with the NVIDIA Template Library information
+architecture: About, Get Started, Use AIStore, Operations, Reference,
+Troubleshooting, and Resources. During the Fern migration, this page is the
+source for the generated Fern documentation navigation.
 
-## Core Documentation
+## About AIStore
 
 - [Main README](/README.md)
-- [In-depth Overview](/docs/overview.md)
+- [In-depth overview](/docs/overview.md)
 - [Terminology and core abstractions](/docs/terminology.md)
-- [Getting Started](/docs/getting_started.md)
 - [Networking model](/docs/networking.md)
+- [Traffic patterns](/docs/traffic_patterns.md)
+- [Backend providers](/docs/providers.md)
+- [Storage services](/docs/storage_svcs.md)
 - [Buckets: design, operations, namespaces, and system buckets](/docs/bucket.md)
-- [Observability overview](/docs/monitoring-overview.md)
+- [On-disk layout](/docs/on_disk_layout.md)
+- [Highly available control plane](/docs/ha.md)
+
+## Release Notes
+
+- [AIStore 5.0 draft release notes](/docs/relnotes/5.0-draft.md)
+- [AIStore 4.7 release notes](/docs/relnotes/4.7.md)
+- [AIStore 4.6 release notes](/docs/relnotes/4.6.md)
+- [AIStore 4.5 release notes](/docs/relnotes/4.5.md)
+- [AIStore 4.4 release notes](/docs/relnotes/4.4.md)
+- [AIStore 4.3 release notes](/docs/relnotes/4.3.md)
+- [AIStore 4.2 release notes](/docs/relnotes/4.2.md)
+- [AIStore 4.1 release notes](/docs/relnotes/4.1.md)
+- [AIStore 4.0 release notes](/docs/relnotes/4.0.md)
+- [AIStore 3.30 release notes](/docs/relnotes/3.30.md)
+
+## Get Started
+
+- [Getting Started](/docs/getting_started.md)
+- [Docker](/docs/docker_main.md)
+- [AIS in containerized environments](/docs/containerized.md)
+- [Configuration](/docs/configuration.md)
+- [Environment variables](/docs/environment-vars.md)
+- [HTTPS and certificates](/docs/https.md)
+- [Switching a cluster to HTTPS](/docs/switch_https.md)
+
+## Use AIStore
+
 - [CLI overview](/docs/cli.md)
-- [Production deployment](https://github.com/NVIDIA/aistore/blob/main/deploy/README.md)
-- [Technical Blog](https://aistore.nvidia.com/blog)
-
-## APIs, SDKs, and Compatibility
-
-- [Go API](https://github.com/NVIDIA/aistore/tree/main/api)
-- [Python SDK](https://github.com/NVIDIA/aistore/tree/main/python/aistore)
-  - [PyPI package](https://pypi.org/project/aistore/)
-  - [Python SDK reference guide](https://docs.nvidia.com/aistore/python/aistore/sdk)
-- [PyTorch integration](https://docs.nvidia.com/aistore/python/aistore/pytorch)
-- [TensorFlow integration](/docs/tensorflow.md)
-- [HTTP API reference](https://aistore.nvidia.com/docs/http-api)
-  - [curl examples](/docs/http_api.md)
-  - [Easy URL](/docs/easy_url.md)
-- [S3 compatibility](/docs/s3compat.md)
-  - [`s3cmd` quick start](/docs/s3compat.md#quick-start-with-s3cmd)
-  - [Presigned S3 requests](/docs/s3compat.md#presigned-s3-requests)
-  - [Boto3 support](https://docs.nvidia.com/aistore/python/aistore/botocore_patch)
-
-## Command-Line Interface
-
-- [CLI overview](/docs/cli.md)
-- [`ais help`](/docs/cli/help.md)
-- [CLI reference guide](https://github.com/NVIDIA/aistore/blob/main/docs/cli.md#cli-reference)
 - [Bucket operations](/docs/cli/bucket.md)
 - [Cluster and remote-cluster management](/docs/cli/cluster.md)
 - [Storage and mountpath management](/docs/cli/storage.md)
-- [Monitoring and `ais show`](/docs/cli/show.md)
 - [Downloads](/docs/cli/download.md)
 - [Jobs](/docs/cli/job.md)
-- [Authentication and access control](/docs/cli/auth.md)
-- [Configuration via CLI](/docs/cli/config.md)
-- [ETL CLI](/docs/cli/etl.md)
-- [Distributed shuffle CLI](/docs/cli/dsort.md)
-- [ML / get-batch CLI](/docs/cli/ml.md)
-- [GCP credentials](/docs/cli/gcp_creds.md)
-- [TLS certificate management](/docs/cli/x509.md)
-
-## Storage and Data Management
-
-- [Storage services](/docs/storage_svcs.md)
-- [Buckets: design, operations, namespaces, and system buckets](/docs/bucket.md)
-- [Native Bucket Inventory (NBI)](/docs/nbi.md)
-- [Shard Index](/docs/shard_index.md)
-- [Backend providers](/docs/providers.md)
-- [On-disk layout](/docs/on_disk_layout.md)
-- [Virtual directories](/docs/howto_virt_dirs.md)
-- [System files](/docs/sysfiles.md)
-- [Evicting remote buckets and cached data](/docs/cli/evicting_buckets_andor_data.md)
-
-## Cluster Operations
-
-- [Node lifecycle: maintenance, shutdown, decommission](/docs/lifecycle_node.md)
-- [Global rebalance](/docs/rebalance.md)
-- [Resilver](/docs/resilver.md)
-- [AIS in Containerized Environments](/docs/containerized.md)
-- [Highly available control plane](/docs/ha.md)
-- [Information Center (IC)](/docs/ic.md)
-- [Out-of-band updates](/docs/out_of_band.md)
-- [Troubleshooting](/docs/troubleshooting.md)
-
-## Configuration and Security
-
-- [Configuration](/docs/configuration.md)
-- [Environment variables](/docs/environment-vars.md)
-- [Feature flags](/docs/feature_flags.md)
-- [AuthN and access control](/docs/authn.md)
-- [Authentication validation](/docs/auth_validation.md)
-- [HTTPS and certificates](/docs/https.md)
-  - [Switching a cluster to HTTPS](/docs/switch_https.md)
-
-## ETL and Advanced Workflows
-
 - [ETL overview](/docs/etl.md)
 - [ETL CLI docs](/docs/cli/etl.md)
-- [ETL Python SDK examples](https://github.com/NVIDIA/aistore/tree/main/python/examples/ais-etl)
-- [Custom transformers](https://github.com/NVIDIA/ais-etl/tree/main/transformers)
-- [ETL Python webserver SDK](https://github.com/NVIDIA/aistore/blob/main/python/aistore/sdk/etl/webserver/README.md)
-- [ETL Go webserver package](https://github.com/NVIDIA/aistore/blob/main/ext/etl/webserver/README.md)
 - [Archives: read, write, and list](/docs/archive.md)
-- [Shard Index](/docs/shard_index.md)
 - [Distributed shuffle (`dsort`)](/docs/dsort.md)
-- [Initial sharding utility (`ishard`)](https://github.com/NVIDIA/aistore/blob/main/cmd/ishard/README.md)
 - [Downloader](/docs/downloader.md)
 - [Blob Downloader](/docs/blob_downloader.md)
 - [Batch object retrieval (get-batch)](/docs/get_batch.md)
 - [Batch operations](/docs/batch.md)
-- [Tools and utilities](https://github.com/NVIDIA/aistore/blob/main/cmd/README.md)
-- [Extended actions (xactions)](https://github.com/NVIDIA/aistore/blob/main/xact/README.md)
+- [Virtual directories](/docs/howto_virt_dirs.md)
 
-## Observability, Monitoring, and Performance
+## Operations
+
+- [Production deployment](https://github.com/NVIDIA/aistore/blob/main/deploy/README.md)
+- [AIStore on Kubernetes](https://github.com/NVIDIA/ais-k8s)
+- [Kubernetes Operator](https://github.com/NVIDIA/ais-k8s/blob/main/operator/README.md)
+- [Ansible playbooks](https://github.com/NVIDIA/ais-k8s/blob/main/playbooks/README.md)
+- [Helm charts](https://github.com/NVIDIA/ais-k8s/tree/main/helm)
+- [Deployment monitoring](https://github.com/NVIDIA/ais-k8s/blob/main/monitoring/README.md)
+- [Node lifecycle: maintenance, shutdown, decommission](/docs/lifecycle_node.md)
+- [Global rebalance](/docs/rebalance.md)
+- [Resilver](/docs/resilver.md)
+- [Information Center (IC)](/docs/ic.md)
+- [Out-of-band updates](/docs/out_of_band.md)
+- [Native Bucket Inventory (NBI)](/docs/nbi.md)
+- [System files](/docs/sysfiles.md)
+
+## Observability and Performance
 
 - [Observability overview](/docs/monitoring-overview.md)
 - [Monitoring with CLI](/docs/monitoring-cli.md)
@@ -128,32 +101,51 @@ AIStore documentation is organized by task: getting started, accessing AIS via C
 - [Rate limiting](/docs/rate_limit.md)
 - [Checksumming](/docs/checksum.md)
 - [Filesystem Health Checker (FSHC)](/docs/fshc.md)
-- [Traffic patterns](/docs/traffic_patterns.md)
 
-## Networking
+## Reference
 
-- [Networking: multi-homing, network separation, IPv6](/docs/networking.md)
-- [HTTPS configuration](/docs/https.md)
-- [Switching to HTTPS](/docs/switch_https.md)
-- [Idle connections](/docs/idle_connections.md)
+- [`ais help`](/docs/cli/help.md)
+- [CLI reference guide](https://github.com/NVIDIA/aistore/blob/main/docs/cli.md#cli-reference)
+- [Go API](https://github.com/NVIDIA/aistore/tree/main/api)
+- [Python SDK](https://github.com/NVIDIA/aistore/tree/main/python/aistore)
+- [PyPI package](https://pypi.org/project/aistore/)
+- [Python SDK reference guide](https://docs.nvidia.com/aistore/python/aistore/sdk)
+- [PyTorch integration](https://docs.nvidia.com/aistore/python/aistore/pytorch)
+- [TensorFlow integration](/docs/tensorflow.md)
+- [HTTP API reference](https://aistore.nvidia.com/docs/http-api)
+- [curl examples](/docs/http_api.md)
+- [Easy URL](/docs/easy_url.md)
+- [S3 compatibility](/docs/s3compat.md)
+- [`s3cmd` quick start](/docs/s3compat.md#quick-start-with-s3cmd)
+- [Presigned S3 requests](/docs/s3compat.md#presigned-s3-requests)
+- [Boto3 support](https://docs.nvidia.com/aistore/python/aistore/botocore_patch)
+- [Authentication and access control](/docs/cli/auth.md)
+- [Configuration via CLI](/docs/cli/config.md)
+- [GCP credentials](/docs/cli/gcp_creds.md)
+- [TLS certificate management](/docs/cli/x509.md)
+- [Feature flags](/docs/feature_flags.md)
+- [AuthN and access control](/docs/authn.md)
+- [Authentication validation](/docs/auth_validation.md)
 - [MessagePack protocol](/docs/msgp.md)
-
-## Deployment
-
-- [AIStore on Kubernetes](https://github.com/NVIDIA/ais-k8s)
-- [Kubernetes Operator](https://github.com/NVIDIA/ais-k8s/blob/main/operator/README.md)
-- [Ansible playbooks](https://github.com/NVIDIA/ais-k8s/blob/main/playbooks/README.md)
-- [Helm charts](https://github.com/NVIDIA/ais-k8s/tree/main/helm)
-- [Deployment monitoring](https://github.com/NVIDIA/ais-k8s/blob/main/monitoring/README.md)
-- [Docker](/docs/docker_main.md)
-
-## Developer Resources
-
-- [Development guide](/docs/development.md)
-- [`aisnode` command line](/docs/command_line.md)
-- [Build tags](/docs/build_tags.md)
-
-## Object and Bucket Naming
-
+- [Idle connections](/docs/idle_connections.md)
+- [Shard Index](/docs/shard_index.md)
 - [Unicode and special symbols in object and bucket names](/docs/unicode.md)
 - [Extremely long object names](/docs/long_names.md)
+- [Build tags](/docs/build_tags.md)
+- [`aisnode` command line](/docs/command_line.md)
+
+## Troubleshooting
+
+- [Troubleshooting](/docs/troubleshooting.md)
+
+## Resources
+
+- [Technical Blog](https://aistore.nvidia.com/blog)
+- [Development guide](/docs/development.md)
+- [Tools and utilities](https://github.com/NVIDIA/aistore/blob/main/cmd/README.md)
+- [Extended actions (xactions)](https://github.com/NVIDIA/aistore/blob/main/xact/README.md)
+- [ETL Python SDK examples](https://github.com/NVIDIA/aistore/tree/main/python/examples/ais-etl)
+- [Custom transformers](https://github.com/NVIDIA/ais-etl/tree/main/transformers)
+- [ETL Python webserver SDK](https://github.com/NVIDIA/aistore/blob/main/python/aistore/sdk/etl/webserver/README.md)
+- [ETL Go webserver package](https://github.com/NVIDIA/aistore/blob/main/ext/etl/webserver/README.md)
+- [Initial sharding utility (`ishard`)](https://github.com/NVIDIA/aistore/blob/main/cmd/ishard/README.md)


### PR DESCRIPTION
## Summary

Reorganizes `docs/docs.md`, the source for generated Fern documentation navigation, into the NVIDIA Template Library information architecture:

- About AIStore
- Release Notes
- Get Started
- Use AIStore
- Operations
- Observability and Performance
- Reference
- Troubleshooting
- Resources

This is intentionally source-only: no page moves, no slug renames, and no generated `fern/docs.yml` churn committed. The goal is to make the Fern migration navigation reviewable before deeper content reshaping.

## Related

- Jira: NSVISCS-11566
- Part of the AIStore Fern migration and docs IA cleanup work.

## Verification

- `bash scripts/fern/generate-pages.sh`
- `npm exec --yes --package fern-api@5.50.5 -- fern check`
  - Result: 0 errors, 1 existing warning for missing generated `./pages/python` when `fern docs md generate` is not run locally.
- `git diff --check`

Generated `fern/docs.yml` was restored after validation so the PR stays limited to the source navigation file.
