### PR TITLE
docs: add Fern preview check workflow

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -1,6 +1,12 @@
 name: Fern Docs
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'fern/**'
+      - 'scripts/fern/**'
   push:
     branches: [main]
     paths:
@@ -11,8 +17,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    name: Check Fern docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Validate Fern docs without publishing
+        run: bash scripts/fern/generate-pages.sh --check
+
   publish:
     name: Publish Fern docs
+    needs: check
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,35 @@ $ make python_etl_tests
 $ make python_botocore_tests
 ```
 
+#### Previewing Documentation Changes
+
+The production website is still built from `docs/` with Jekyll and Netlify
+(`netlify.toml` runs `bundle exec jekyll build` inside `docs/`). Fern is
+available as a separate preview and validation surface for contributors.
+
+To validate the Fern docs configuration without publishing:
+
+```console
+$ cd aistore
+$ python3 -m pip install pyyaml
+$ npm install -g fern-api
+$ bash scripts/fern/generate-pages.sh --check
+```
+
+`make fern-check` is available as a convenience wrapper for the same check.
+
+To run the local Fern preview:
+
+```console
+$ make fern-preview
+```
+
+`make fern-preview` serves the Fern docs at `http://localhost:3000`.
+If `FERN_TOKEN` is not set, the local preview uses a stub Python API
+reference page; set `FERN_TOKEN` before running the command to include the
+generated Python API reference. Do not use `make fern-build` for local
+checks; it publishes to Fern.
+
 
 #### Signing-Off Commits
 

--- a/Makefile
+++ b/Makefile
@@ -408,10 +408,13 @@ api-docs-website: ## Generate API docs from code annotations
 # Fern documentation
 #
 
-.PHONY: fern-generate fern-preview fern-build
+.PHONY: fern-generate fern-check fern-preview fern-build
 
 fern-generate: ## Generate Fern pages from docs/
 	@$(SHELL) $(SCRIPTS_DIR)/fern/generate-pages.sh
+
+fern-check: ## Generate Fern pages and validate Fern config (no publish)
+	@$(SHELL) $(SCRIPTS_DIR)/fern/generate-pages.sh --check
 
 fern-preview: ## Generate Fern pages and start local preview
 	@$(SHELL) $(SCRIPTS_DIR)/fern/generate-pages.sh --preview

--- a/scripts/fern/generate-pages.sh
+++ b/scripts/fern/generate-pages.sh
@@ -166,9 +166,9 @@ python3 "$SCRIPTS_DIR/mdx-escape.py" "$FERN_PAGES"
 
 echo "Fern pages generated: $(find "$FERN_PAGES" -name '*.md' | wc -l) files"
 
-# ── Optional: preview or build ───────────────────────────────────────────
+# ── Optional: preview, check, or build ───────────────────────────────────
 
-if [[ "${1:-}" == "--preview" || "${1:-}" == "--build" ]]; then
+if [[ "${1:-}" == "--preview" || "${1:-}" == "--check" || "${1:-}" == "--build" ]]; then
     if ! command -v fern &>/dev/null; then
         echo "ERROR: 'fern' CLI not found. Install with: npm install -g fern-api" >&2
         exit 1
@@ -208,7 +208,13 @@ EOF
 
     if [[ "${1:-}" == "--preview" ]]; then
         fern docs dev --port 3000
+    elif [[ "${1:-}" == "--check" ]]; then
+        fern check
     else
         fern generate --docs
     fi
+elif [[ -n "${1:-}" ]]; then
+    echo "ERROR: Unknown option: $1" >&2
+    echo "Usage: scripts/fern/generate-pages.sh [--preview|--check|--build]" >&2
+    exit 1
 fi


### PR DESCRIPTION
## Summary

Adds a Fern documentation validation workflow and contributor-facing local preview/check instructions.

Changes:

- Adds `.github/workflows/fern-docs.yml` for PR validation on Fern/docs-related changes.
- Adds `make fern-generate`, `make fern-check`, `make fern-preview`, and `make fern-build` targets.
- Updates `scripts/fern/generate-pages.sh` so local checks can create a Python API reference stub when `FERN_TOKEN` is not available.
- Adds contributor documentation for local Fern preview and validation.

## Related

- Jira: NSVISCS-11564
- Companion IA-only PR: https://github.com/NVIDIA/aistore/pull/327

## Verification

- `bash scripts/fern/generate-pages.sh`
- `npm exec --yes --package fern-api@5.50.5 -- fern check`
  - Result: 0 errors, 1 existing warning for missing generated `./pages/python` when `fern docs md generate` is not run locally.
- `git diff --check`

Note: full `make fern-generate`/Go-adjacent verification is still limited in this local environment because `go` is not installed.
