### PR TITLE
etl/webserver: fix direct-put response forwarding

### DIFF
--- a/ext/etl/webserver/cmn.go
+++ b/ext/etl/webserver/cmn.go
@@ -36,6 +36,7 @@ func wrapHTTPError(resp *http.Response, err error) (*http.Response, error) {
 			return resp, errors.New(resp.Status)
 		}
 		b, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			return resp, err
 		}

--- a/ext/etl/webserver/webserver.go
+++ b/ext/etl/webserver/webserver.go
@@ -269,32 +269,35 @@ func (base *etlServerBase) handleWebsocketPipeline(conn *websocket.Conn, transfo
 	firstURL, remainingPipeline := parsePipelineURL(pipeline)
 	dresp, err := base.directPut(firstURL, transformed, size, objPath, remainingPipeline, etlArgs)
 	if err != nil {
-		writer, _ := conn.NextWriter(websocket.TextMessage)
-		writer.Write([]byte(err.Error()))
-		writer.Close()
+		if writer, werr := conn.NextWriter(websocket.TextMessage); werr == nil {
+			writer.Write([]byte(err.Error()))
+			writer.Close()
+		}
 		return err
+	}
+	if dresp.Body != nil {
+		defer dresp.Body.Close()
 	}
 
 	if dresp.StatusCode == http.StatusOK {
 		// from other ETL server, forward the content back
-		writer, _ := conn.NextWriter(websocket.BinaryMessage)
-		if dresp.Size > 0 && dresp.Body != nil {
-			if _, err := io.Copy(writer, dresp.Body); err != nil {
-				return err
-			}
-			dresp.Body.Close()
-		}
-		writer.Close()
-	} else {
-		// from target, no content
-		writer, _ := conn.NextWriter(websocket.TextMessage)
-		_, err = writer.Write([]byte("direct put success"))
+		writer, err := conn.NextWriter(websocket.BinaryMessage)
 		if err != nil {
 			return err
 		}
-		writer.Close()
+		defer writer.Close()
+		_, err = io.Copy(writer, dresp.Body)
+		return err
 	}
-	return nil
+
+	// from target, no content
+	writer, err := conn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+	_, err = writer.Write([]byte("direct put success"))
+	return err
 }
 
 func (base *etlServerBase) handleDirectPut(w http.ResponseWriter, transformedReader io.ReadCloser, size int64, objPath, directPutURL, etlArgs string) {
@@ -304,11 +307,15 @@ func (base *etlServerBase) handleDirectPut(w http.ResponseWriter, transformedRea
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	w.WriteHeader(dresp.StatusCode)
-	if dresp.Size > 0 && dresp.Body != nil {
+	if dresp.Body != nil {
 		setResponseHeaders(w.Header(), dresp.Size)
-		_, err := io.Copy(w, dresp.Body)
-		if err != nil {
+	}
+	if dresp.DirectPutLength > 0 {
+		w.Header().Set(apc.HdrDirectPutLength, strconv.FormatInt(dresp.DirectPutLength, 10))
+	}
+	w.WriteHeader(dresp.StatusCode)
+	if dresp.Body != nil {
+		if _, err := io.Copy(w, dresp.Body); err != nil {
 			nlog.Errorln("copy error", err)
 		}
 		dresp.Body.Close()
@@ -328,7 +335,7 @@ func (base *etlServerBase) handleETLObjectDownload(w http.ResponseWriter, r *htt
 		return
 	}
 
-	resp, err := wrapHTTPError(base.client.Do(req)) //nolint:bodyclose // closed below
+	resp, err := wrapHTTPError(base.client.Do(req))
 	if err != nil {
 		cmn.WriteErr(w, r, fmt.Errorf("failed to download from %s: %w", link, err))
 		return
@@ -429,12 +436,12 @@ func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size 
 	if remainingPipelineURL != "" {
 		req.Header.Set(apc.HdrNodeURL, remainingPipelineURL)
 	}
-	resp, err := wrapHTTPError(base.client.Do(req)) //nolint:bodyclose // closed below
+	resp, err := wrapHTTPError(base.client.Do(req))
 	if err != nil {
 		return nil, err
 	}
 
-	length := cos.ContentLengthUnknown
+	length := 0
 	directPutLength, err := strconv.Atoi(resp.Header.Get(apc.HdrDirectPutLength))
 	if err == nil {
 		length = directPutLength
@@ -442,6 +449,7 @@ func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size 
 
 	// delivered to target, no content
 	if resp.StatusCode == http.StatusNoContent {
+		resp.Body.Close()
 		return &directPutResponse{
 			StatusCode:      http.StatusNoContent,
 			DirectPutLength: int64(length),
@@ -450,21 +458,28 @@ func (base *etlServerBase) directPut(directPutURL string, r io.ReadCloser, size 
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		// from other ETL server, forward the content back
-		if resp.ContentLength > 0 {
+		// NOTE: keyed on Content-Length, not the read body (contrast Python's
+		// handle_direct_put_response): a chunked 200 (ContentLength == -1) is
+		// always forwarded as content - an empty transform result is a valid
+		// object. Python currently maps any empty 200 body to 204/"delivered";
+		// to be aligned with this behavior in a separate PR.
+
+		// from target, no content
+		if resp.ContentLength == 0 {
+			resp.Body.Close()
 			return &directPutResponse{
-				StatusCode:      resp.StatusCode,
-				Size:            resp.ContentLength,
-				DirectPutLength: 0,
-				Body:            resp.Body,
+				StatusCode:      http.StatusNoContent,
+				Size:            0,
+				DirectPutLength: size,
+				Body:            nil,
 			}, nil
 		}
-		// from target, no content
+		// from other ETL server, forward the content back (ContentLength > 0 or unknown/chunked)
 		return &directPutResponse{
-			StatusCode:      http.StatusNoContent,
-			Size:            0,
-			DirectPutLength: size,
-			Body:            nil,
+			StatusCode:      resp.StatusCode,
+			Size:            resp.ContentLength,
+			DirectPutLength: 0,
+			Body:            resp.Body,
 		}, nil
 	}
 

--- a/ext/etl/webserver/webserver_internal_test.go
+++ b/ext/etl/webserver/webserver_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -265,6 +266,133 @@ func TestETLServerDirectPutForwardsArgs(t *testing.T) {
 	})
 }
 
+func TestETLServerDirectPutResponseForwarding(t *testing.T) {
+	var (
+		secretPrefix = "/v1/_object/some_secret"
+		host         = "http://0.0.0.0"
+		port         = "8080"
+
+		svr = &etlServerBase{
+			aisTargetURL: host + secretPrefix,
+			endpoint:     host + ":" + port,
+			client:       &http.Client{},
+			ETLServer:    &EchoServer{},
+		}
+
+		directPutPath = "ais@#test/obj"
+	)
+
+	t.Run("204 forwards Direct-Put-Length", func(t *testing.T) {
+		const directPutLength = 1234
+		directPutTargetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tassert.Fatalf(t, r.Method == http.MethodPut, "expected PUT method, got %s", r.Method)
+			w.Header().Set(apc.HdrDirectPutLength, strconv.Itoa(directPutLength))
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer directPutTargetServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+		)
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(directPutTargetServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		tassert.Fatalf(t, http.StatusNoContent == resp.StatusCode, "expected status code 204, got %d", resp.StatusCode)
+		got := resp.Header.Get(apc.HdrDirectPutLength)
+		tassert.Fatalf(t, got == strconv.Itoa(directPutLength), "expected Direct-Put-Length %d, got %q", directPutLength, got)
+	})
+
+	t.Run("200 forward preserves headers", func(t *testing.T) {
+		nextStageContent := []byte("next stage content")
+		nextStageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tassert.Fatalf(t, r.Method == http.MethodPut, "expected PUT method, got %s", r.Method)
+			w.WriteHeader(http.StatusOK)
+			w.Write(nextStageContent)
+		}))
+		defer nextStageServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+		)
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(nextStageServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		result, _ := io.ReadAll(resp.Body)
+
+		tassert.Fatalf(t, http.StatusOK == resp.StatusCode, "expected status code 200, got %d", resp.StatusCode)
+		tassert.Fatalf(t, bytes.Equal(result, nextStageContent), "expected body %s, got %s", nextStageContent, result)
+		tassert.Fatalf(t, resp.Header.Get(cos.HdrContentLength) == strconv.Itoa(len(nextStageContent)),
+			"expected Content-Length %d, got %q", len(nextStageContent), resp.Header.Get(cos.HdrContentLength))
+		tassert.Fatalf(t, resp.Header.Get(cos.HdrContentType) == GetContentType,
+			"expected Content-Type %q, got %q", GetContentType, resp.Header.Get(cos.HdrContentType))
+	})
+
+	t.Run("200 chunked body not dropped", func(t *testing.T) {
+		chunk1 := []byte("first chunk ")
+		chunk2 := []byte("second chunk")
+		nextStageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tassert.Fatalf(t, r.Method == http.MethodPut, "expected PUT method, got %s", r.Method)
+			w.WriteHeader(http.StatusOK)
+			w.Write(chunk1)
+			w.(http.Flusher).Flush() // force chunked transfer so ContentLength == -1 on the client side
+			w.Write(chunk2)
+		}))
+		defer nextStageServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+		)
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(nextStageServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		result, _ := io.ReadAll(resp.Body)
+
+		tassert.Fatalf(t, http.StatusOK == resp.StatusCode, "expected status code 200, got %d", resp.StatusCode)
+		expected := append(append([]byte{}, chunk1...), chunk2...)
+		tassert.Fatalf(t, bytes.Equal(result, expected), "expected body %s, got %s", expected, result)
+	})
+
+	t.Run("200 empty body maps to 204", func(t *testing.T) {
+		nextStageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tassert.Fatalf(t, r.Method == http.MethodPut, "expected PUT method, got %s", r.Method)
+			w.WriteHeader(http.StatusOK) // no body; client sees ContentLength == 0
+		}))
+		defer nextStageServer.Close()
+
+		var (
+			content = []byte("test bytes")
+			req     = httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(content))
+			w       = httptest.NewRecorder()
+		)
+		req.Header = http.Header{apc.HdrNodeURL: []string{cos.JoinPath(nextStageServer.URL, url.PathEscape(directPutPath))}}
+
+		svr.putHandler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		tassert.Fatalf(t, http.StatusNoContent == resp.StatusCode, "expected status code 204, got %d", resp.StatusCode)
+		got := resp.Header.Get(apc.HdrDirectPutLength)
+		tassert.Fatalf(t, got == strconv.Itoa(len(content)), "expected Direct-Put-Length %d, got %q", len(content), got)
+	})
+}
+
 func TestEchoServerGetHandler(t *testing.T) {
 	var (
 		secretPrefix = "/v1/_object/some_secret"
@@ -465,6 +593,62 @@ func TestWebSocketHandler(t *testing.T) {
 	err = conn3.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye"))
 	tassert.CheckFatal(t, err)
 	tassert.CheckFatal(t, conn3.Close())
+}
+
+func TestWebSocketDirectPutChunkedForward(t *testing.T) {
+	var (
+		originalData = []byte("hello")
+		directPutURL = "/ais/etl_dst/obj"
+
+		secretPrefix = "/v1/_object/some_secret"
+		host         = "http://0.0.0.0"
+		port         = "8080"
+
+		chunk1 = []byte("first chunk ")
+		chunk2 = []byte("second chunk")
+	)
+
+	// Next pipeline stage: returns 200 with an unknown-length (chunked) body.
+	nextStageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		tassert.Fatalf(t, bytes.Equal(data, originalData), "direct PUT got unexpected data")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chunk1)
+		w.(http.Flusher).Flush() // force chunked transfer so ContentLength == -1 on the client side
+		w.Write(chunk2)
+	}))
+	defer nextStageServer.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ws" {
+			base := &etlServerBase{
+				aisTargetURL: host + secretPrefix,
+				endpoint:     host + ":" + port,
+				client:       &http.Client{},
+				ETLServer:    &EchoServer{},
+			}
+			base.websocketHandler(w, r)
+		}
+	}))
+	defer wsSrv.Close()
+
+	u := "ws" + strings.TrimPrefix(wsSrv.URL, "http") + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil) //nolint:bodyclose // closed below
+	tassert.Fatalf(t, err == nil, "WebSocket connection failed: %v", err)
+
+	err = conn.WriteJSON(etl.WebsocketCtrlMsg{Pipeline: nextStageServer.URL + directPutURL})
+	tassert.Fatalf(t, err == nil, "Write JSON failed")
+	err = conn.WriteMessage(websocket.BinaryMessage, originalData)
+	tassert.Fatalf(t, err == nil, "Write message failed")
+
+	mt, msg, err := conn.ReadMessage()
+	tassert.CheckError(t, err)
+	err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye"))
+	tassert.CheckError(t, err)
+	tassert.CheckError(t, conn.Close())
+	tassert.Fatalf(t, mt == websocket.BinaryMessage, "Expected BinaryMessage")
+	expected := append(append([]byte{}, chunk1...), chunk2...)
+	tassert.Fatalf(t, bytes.Equal(msg, expected), "expected content %s, got %s", expected, msg)
 }
 
 func createFQNFile(t *testing.T) (string, []byte) {


### PR DESCRIPTION
This PR fixes direct-put response forwarding in the Go ETL webserver.

Before this change, `directPut` treated any 200 response without a positive
`Content-Length` as "delivered to target, no content". Chunked/unknown-length
200 responses from the next pipeline stage (e.g. a streaming ETL server) were
silently dropped while still reporting success. In addition, `handleDirectPut`
set response headers after `WriteHeader` (so they were never sent), never
forwarded `Direct-Put-Length`, and leaked response bodies on several paths.

Changes:
- treat only `Content-Length: 0` as the no-content case; forward
  chunked/unknown-length 200 bodies back as content
- set response headers before `WriteHeader`; forward `Direct-Put-Length` on 204
- close direct-put response bodies on all paths (HTTP and websocket)
- align 200-empty-body handling with the Python servers'
  `handle_direct_put_response` for cross-language parity