### PR TITLE
xs/lrit: make 429 retry backoff abort-aware

### DIFF
--- a/xact/xs/lrit.go
+++ b/xact/xs/lrit.go
@@ -357,7 +357,13 @@ func (r *lrit) lsoPage(bp core.Backend, lsmsg *apc.LsoMsg, lst *cmn.LsoRes) (eco
 	)
 	for retries = 1; retries < remPageRetriesMax; retries++ {
 		sleep = hk.Jitter(sleep+sleep/2, now+int64(sleep))
-		time.Sleep(sleep)
+		timer := time.NewTimer(sleep)
+		select {
+		case <-timer.C:
+		case <-r.parent.ChanAbort():
+			timer.Stop()
+			return ecode, err
+		}
 		total += sleep
 
 		ecode, err = bp.ListObjects(r.bck, lsmsg, lst)


### PR DESCRIPTION
## What
`lsoPage` (added in bb6ac0023) retries remote list-objects on 429 with an
escalating backoff — but the backoff uses a plain `time.Sleep`, which is not
interruptible. Aborting a list/range (multi-object) job mid-backoff blocks
until the sleep finishes: up to ~10s for a single attempt and ~26s cumulative
across all retries.
## Fix
Replace `time.Sleep` with a `select` on the parent xaction's abort channel
(the same idiom already used elsewhere in `lrit.go` and other xactions).
On abort, return the pending too-many-requests error — identical to the
behavior of the existing post-call `IsAborted()` checks, just prompt.

