### PR TITLE
oci: fix 429 wrapped with nil error (nil-deref panic in ErrTooManyRequests.Error)

### DIFF
--- a/ais/backend/oci.go
+++ b/ais/backend/oci.go
@@ -392,7 +392,7 @@ func ociErrorToAISError(op, bucketName, objectPath, byteRange string, errIn erro
 	case http.StatusRequestedRangeNotSatisfiable:
 		errOut = cos.NewErrRangeNotSatisfiable(errIn, []string{byteRange}, 0)
 	case http.StatusTooManyRequests:
-		errOut = cmn.NewErrTooManyRequests(nil, statusCode)
+		errOut = cmn.NewErrTooManyRequests(errIn, statusCode)
 	default:
 		if bucketName == "" {
 			path = objectPath // possibly itself also ""

--- a/ais/backend/oci_internal_test.go
+++ b/ais/backend/oci_internal_test.go
@@ -9,6 +9,8 @@ package backend
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -197,5 +199,31 @@ func TestOCIClientCreatesRegionClientOnce(t *testing.T) {
 		if first != client {
 			t.Fatal("expected all goroutines to receive the same cached client instance")
 		}
+	}
+}
+
+// Regression test: a 429 from OCI must yield an ErrTooManyRequests that carries
+// the SDK error. Previously the OCI backend passed nil to NewErrTooManyRequests,
+// so the first Error() call (e.g. xaction AddErr on the prefetch path) panicked
+// with a nil-pointer dereference and crashed the target.
+func TestOCIErrorToAISError429(t *testing.T) {
+	errSDK := errors.New("Error returned by ObjectStorage Service. Http Status Code: 429. Error Code: TooManyRequests.")
+	resp := ocios.GetObjectResponse{
+		RawResponse: &http.Response{StatusCode: http.StatusTooManyRequests},
+	}
+
+	ecode, err := ociErrorToAISError("GetObj", "test-bucket", "test/object", "", errSDK, resp)
+	if ecode != http.StatusTooManyRequests {
+		t.Fatalf("expected status %d, got %d", http.StatusTooManyRequests, ecode)
+	}
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if !cmn.IsErrTooManyRequests(err) {
+		t.Fatalf("expected ErrTooManyRequests, got %T (%v)", err, err)
+	}
+	// must not panic, and must carry the SDK error text
+	if msg := err.Error(); !strings.Contains(msg, "429") {
+		t.Fatalf("error text should carry the SDK message, got %q", msg)
 	}
 }

--- a/cmn/err.go
+++ b/cmn/err.go
@@ -1032,7 +1032,7 @@ func IsErrXactNonIC(err error) bool {
 // ErrTooManyRequests (429, 503)
 
 func NewErrTooManyRequests(err error, status int) *ErrTooManyRequests {
-	debug.Assert(!cos.IsTypedNil(err))
+	debug.Assert(err != nil && !cos.IsTypedNil(err)) // Error() derefs it; IsTypedNil alone lets untyped nil through
 	return &ErrTooManyRequests{err, status}
 }
 


### PR DESCRIPTION
**Problem** — When OCI Object Storage returns HTTP 429, `ociErrorToAISError` wraps it as `cmn.NewErrTooManyRequests(nil, statusCode)` — the only nil-passing call site of that constructor (aws/azure/gcp all pass a non-nil error). The first `Error()` call — e.g. `xact.(*Base).AddErr` on the prefetch path, `lsoPage` give-up logging, or `WriteErr` — dereferences the nil and crashes the target with SIGSEGV. Under sustained throttling this becomes a cluster-wide crash loop (we hit this in production: 34 targets, ~15s cycle, restart counters >1700).

Fixes #338.

**Fix** — pass `errIn`, which is non-nil whenever `statusCode` derives from a response (every `ocios.*Response`-passing caller sits in an `err != nil` branch); mirrors the adjacent 416 case. Also tightens the constructor's guard — `cos.IsTypedNil(nil)` returns `false` for untyped nil, so the existing assert couldn't catch this even in debug builds.

**Test** — `TestOCIErrorToAISError429` feeds a 429 `RawResponse` + SDK error through `ociErrorToAISError`; on the unfixed code it reproduces the exact production panic (nil-deref, `addr=0x18`). It is `oci`-tagged like the rest of `oci_internal_test.go` and runs via `go test -tags oci ./ais/backend/` (CI lint compiles it under the `oci` tag; CI test jobs use `-tags debug`).
