### PR TITLE
fern: upgrade CLI to v5.75.8

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  FERN_API_VERSION: 5.50.5
+  FERN_API_VERSION: 5.75.8
 
 jobs:
   check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ To validate the Fern docs configuration without publishing:
 ```console
 cd aistore
 python3 -m pip install pyyaml
-npm install -g fern-api@5.50.5
+npm install -g fern-api@5.75.8
 bash scripts/fern/generate-pages.sh --check
 ```
 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.67.1"
+  "version": "5.75.8"
 }


### PR DESCRIPTION
## Summary

- Bump `fern-api` from `5.50.5`/`5.67.1` to `5.75.8` (latest) across all references
- Updated `fern/fern.config.json`, `CONTRIBUTING.md`, and `.github/workflows/fern-docs.yml` consistently

## Test plan

- [ ] Run `make fern-check` to validate docs configuration against new CLI version
- [ ] Run `make fern-preview` and confirm local preview renders at `http://localhost:3000`
- [ ] Confirm CI (`fern-docs` workflow) passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)