### PR TITLE
object: serve and cache cold range reads from remote backend (Range-Cold-GET)

### DIFF
--- a/ais/backend/ht.go
+++ b/ais/backend/ht.go
@@ -190,7 +190,8 @@ func (htbp *htbp) GetObjReader(ctx context.Context, lom *core.LOM, offset, lengt
 	if res.Err != nil {
 		return res
 	}
-	if resp.StatusCode != http.StatusOK {
+	ok := resp.StatusCode == http.StatusOK || (length > 0 && resp.StatusCode == http.StatusPartialContent)
+	if !ok {
 		res.ErrCode = resp.StatusCode
 		res.Err = fmt.Errorf("error occurred: %v", resp.StatusCode)
 		return res

--- a/ais/test/range_coldget_test.go
+++ b/ais/test/range_coldget_test.go
@@ -1,0 +1,272 @@
+// Package integration_test.
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package integration_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/NVIDIA/aistore/api"
+	"github.com/NVIDIA/aistore/api/apc"
+	"github.com/NVIDIA/aistore/cmn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/cmn/feat"
+	"github.com/NVIDIA/aistore/tools"
+	"github.com/NVIDIA/aistore/tools/readers"
+	"github.com/NVIDIA/aistore/tools/tassert"
+	"github.com/NVIDIA/aistore/tools/tlog"
+	"github.com/NVIDIA/aistore/tools/trand"
+)
+
+// feat.RangeColdGET (see ais/tgtfrange.go): a ranged GET of a not-cached object is
+// served directly from the remote backend, and the grid-aligned chunks covering the
+// requested range get cached; once the grid is fully covered the object becomes
+// a regular (chunked) in-cluster object.
+//
+// NOTE: using a remote AIS cluster ("remais") and out-of-band PUTs, so that the
+// objects in question are, initially, not present in this cluster.
+
+const (
+	rcGridSize = 8 * cos.MiB            // must be in sync w/ rcChunkSize (ais/tgtfrange.go)
+	rcObjSize  = 2*rcGridSize + cos.MiB // 3 grid chunks: two full and one partial
+)
+
+// accumulate the grid, one range read at a time
+func TestRangeColdGet(t *testing.T) {
+	var (
+		proxyURL   = tools.RandomProxyURL(t)
+		baseParams = tools.BaseAPIParams(proxyURL)
+		bck        = rcBucket(t, proxyURL)
+		objName    = "range-cold-get-" + trand.String(5)
+		src        = rcPutRemote(t, bck, objName)
+		m          = &ioContext{t: t, bck: bck}
+	)
+	initMountpaths(t, proxyURL)
+	rcCheckPresent(t, proxyURL, bck, objName, false)
+
+	tlog.Logln("1. read the first chunk")
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(0, cos.KiB), src[:cos.KiB])
+	rcCheckPresent(t, proxyURL, bck, objName, false)
+	m.validateChunksOnDisk(bck, objName, -1) // at least one chunk file
+
+	tlog.Logln("2. read the last (partial) chunk - out of order")
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(2*rcGridSize, cos.MiB), src[2*rcGridSize:])
+	rcCheckPresent(t, proxyURL, bck, objName, false)
+
+	tlog.Logln("3. read the remaining gap: unaligned range across the cached chunk #1 and the missing chunk #2")
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(rcGridSize-10, 20), src[rcGridSize-10:rcGridSize+10])
+
+	tlog.Logln("4. the grid is now fully covered: expecting a chunked in-cluster object")
+	rcCheckPresent(t, proxyURL, bck, objName, true)
+	rcCheckChunked(t, baseParams, bck, objName)
+	m.validateChunksOnDisk(bck, objName, 3)
+	rcCheckWhole(t, baseParams, bck, objName, src)
+
+	tlog.Logln("5. warm range read")
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(rcGridSize/2, rcGridSize), src[rcGridSize/2:rcGridSize/2+rcGridSize])
+}
+
+// a single unaligned range covering the entire grid: one backend read that gets
+// split across the grid chunks
+func TestRangeColdGetFullSpan(t *testing.T) {
+	var (
+		proxyURL   = tools.RandomProxyURL(t)
+		baseParams = tools.BaseAPIParams(proxyURL)
+		bck        = rcBucket(t, proxyURL)
+		objName    = "range-cold-get-span-" + trand.String(5)
+		src        = rcPutRemote(t, bck, objName)
+	)
+	initMountpaths(t, proxyURL)
+
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(100, rcObjSize-200), src[100:rcObjSize-100])
+
+	rcCheckPresent(t, proxyURL, bck, objName, true)
+	rcCheckChunked(t, baseParams, bck, objName)
+	rcCheckWhole(t, baseParams, bck, objName, src)
+}
+
+// suffix and open-ended ranges: both require the object size, which the target
+// resolves by HEAD-ing the remote object
+func TestRangeColdGetOpenEnded(t *testing.T) {
+	var (
+		proxyURL   = tools.RandomProxyURL(t)
+		baseParams = tools.BaseAPIParams(proxyURL)
+		bck        = rcBucket(t, proxyURL)
+	)
+	tests := []struct {
+		name     string
+		rng      string
+		from, to int64
+	}{
+		{name: "suffix", rng: "bytes=-100", from: rcObjSize - 100, to: rcObjSize},
+		{name: "open-ended", rng: "bytes=" + strconv.FormatInt(rcObjSize-cos.MiB, 10) + "-", from: rcObjSize - cos.MiB, to: rcObjSize},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objName := "range-cold-get-" + test.name + "-" + trand.String(5)
+			src := rcPutRemote(t, bck, objName)
+			rcGet(t, baseParams, bck, objName, test.rng, src[test.from:test.to])
+
+			// both ranges above are contained in the last grid chunk
+			rcCheckPresent(t, proxyURL, bck, objName, false)
+		})
+	}
+
+	t.Run("out-of-range", func(t *testing.T) {
+		objName := "range-cold-get-oor-" + trand.String(5)
+		rcPutRemote(t, bck, objName)
+
+		hdr := http.Header{cos.HdrRange: []string{"bytes=" + strconv.FormatInt(rcObjSize+1, 10) + "-"}}
+		_, err := api.GetObject(baseParams, bck, objName, &api.GetArgs{Header: hdr})
+		tassert.Fatalf(t, err != nil, "expected an out-of-range error")
+		herr := cmn.AsErrHTTP(err)
+		tassert.Errorf(t, herr != nil && herr.Status == http.StatusRequestedRangeNotSatisfiable,
+			"expected %d, got %v", http.StatusRequestedRangeNotSatisfiable, err)
+	})
+}
+
+// concurrent range reads of a not-cached object: at most one of them fills the cache,
+// the rest get served from the backend and/or the already accumulated chunks
+func TestRangeColdGetConcurrent(t *testing.T) {
+	const numReads = 8
+	var (
+		proxyURL   = tools.RandomProxyURL(t)
+		baseParams = tools.BaseAPIParams(proxyURL)
+		bck        = rcBucket(t, proxyURL)
+		objName    = "range-cold-get-conc-" + trand.String(5)
+		src        = rcPutRemote(t, bck, objName)
+		length     = int64(rcObjSize / numReads)
+		wg         sync.WaitGroup
+		errCh      = make(chan error, numReads)
+	)
+	initMountpaths(t, proxyURL)
+
+	for i := range numReads {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			var (
+				off  = int64(i) * length
+				w    = bytes.NewBuffer(nil)
+				hdr  = http.Header{cos.HdrRange: []string{cmn.MakeRangeHdr(off, length)}}
+				args = api.GetArgs{Writer: w, Header: hdr}
+			)
+			if _, err := api.GetObject(baseParams, bck, objName, &args); err != nil {
+				errCh <- err
+			} else if !bytes.Equal(w.Bytes(), src[off:off+length]) {
+				errCh <- fmt.Errorf("range %d: payload differs from the source", i)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+
+	// the accumulated chunks (if any) must not stand in the way of caching the object
+	rcGet(t, baseParams, bck, objName, cmn.MakeRangeHdr(0, rcObjSize), src)
+	rcCheckPresent(t, proxyURL, bck, objName, true)
+	rcCheckWhole(t, baseParams, bck, objName, src)
+}
+
+//
+// helpers
+//
+
+// remais bucket with the feature enabled (bucket scope)
+func rcBucket(t *testing.T, proxyURL string) cmn.Bck {
+	t.Helper()
+	tools.CheckSkip(t, &tools.SkipTestArgs{RequiresRemoteCluster: true})
+
+	bck := cmn.Bck{Name: trand.String(10), Provider: apc.AIS, Ns: cmn.Ns{UUID: tools.RemoteCluster.UUID}}
+	tools.CreateBucket(t, proxyURL, bck, nil /*props*/, true /*cleanup*/)
+
+	// NOTE: remote buckets ignore the props passed at creation time
+	props := &cmn.BpropsToSet{Features: apc.Ptr(feat.RangeColdGET)}
+	_, err := api.SetBucketProps(tools.BaseAPIParams(proxyURL), bck, props)
+	tassert.CheckFatal(t, err)
+
+	p, err := api.HeadBucket(tools.BaseAPIParams(proxyURL), bck, true /*dontAddRemote*/)
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, p.Features.IsSet(feat.RangeColdGET), "%s: %s is not set", bck.String(), feat.RangeColdGET.Names())
+	return bck
+}
+
+// out-of-band PUT (directly into the remote cluster); return the source bytes
+func rcPutRemote(t *testing.T, bck cmn.Bck, objName string) []byte {
+	t.Helper()
+	const size = int64(rcObjSize)
+	reader, err := readers.New(&readers.Arg{Type: readers.Rand, Size: size, CksumType: cos.ChecksumNone})
+	tassert.CheckFatal(t, err)
+
+	_, err = api.PutObject(&api.PutArgs{
+		BaseParams: tools.BaseAPIParams(tools.RemoteCluster.URL),
+		Bck:        cmn.Bck{Name: bck.Name, Provider: apc.AIS}, // remote cluster: no namespace
+		ObjName:    objName,
+		Reader:     reader,
+		Size:       uint64(size),
+	})
+	tassert.CheckFatal(t, err)
+
+	rd, err := reader.Open()
+	tassert.CheckFatal(t, err)
+	src, err := io.ReadAll(rd)
+	cos.Close(rd)
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, int64(len(src)) == size, "expected %d source bytes, got %d", size, len(src))
+	return src
+}
+
+// ranged GET: validate the payload and the 206 response headers
+func rcGet(t *testing.T, bp api.BaseParams, bck cmn.Bck, objName, rng string, expected []byte) {
+	t.Helper()
+	var (
+		w    = bytes.NewBuffer(nil)
+		hdr  = http.Header{cos.HdrRange: []string{rng}}
+		args = api.GetArgs{Writer: w, Header: hdr}
+	)
+	oah, err := api.GetObject(bp, bck, objName, &args)
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, oah.Size() == int64(len(expected)), "%s: expected %d bytes, got %d", rng, len(expected), oah.Size())
+	tassert.Fatalf(t, bytes.Equal(w.Bytes(), expected), "%s: payload differs from the source", rng)
+
+	respHdr := oah.RespHeader()
+	tassert.Errorf(t, respHdr.Get(cos.HdrAcceptRanges) == "bytes", "%s: %q is not set", rng, cos.HdrAcceptRanges)
+	contentRange := respHdr.Get(cos.HdrContentRange)
+	tassert.Errorf(t, strings.HasSuffix(contentRange, "/"+strconv.FormatInt(rcObjSize, 10)),
+		"%s: unexpected %q: %q", rng, cos.HdrContentRange, contentRange)
+}
+
+func rcCheckPresent(t *testing.T, proxyURL string, bck cmn.Bck, objName string, expected bool) {
+	t.Helper()
+	present := tools.CheckObjIsPresent(proxyURL, bck, objName)
+	tassert.Fatalf(t, present == expected, "%s: expected present=%t", bck.Cname(objName), expected)
+}
+
+func rcCheckChunked(t *testing.T, bp api.BaseParams, bck cmn.Bck, objName string) {
+	t.Helper()
+	lsmsg := &apc.LsoMsg{Props: apc.GetPropsChunked, Prefix: objName, Flags: apc.LsCached}
+	lst, err := api.ListObjects(bp, bck, lsmsg, api.ListArgs{})
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, len(lst.Entries) == 1, "expected 1 cached object, got %d", len(lst.Entries))
+	tassert.Errorf(t, lst.Entries[0].Flags&apc.EntryIsChunked != 0, "%s must be chunked", objName)
+}
+
+func rcCheckWhole(t *testing.T, bp api.BaseParams, bck cmn.Bck, objName string, src []byte) {
+	t.Helper()
+	r, size, err := api.GetObjectReader(bp, bck, objName, nil /*args*/)
+	tassert.CheckFatal(t, err)
+	tassert.Fatalf(t, size == int64(len(src)), "expected %d bytes, got %d", len(src), size)
+	equal := tools.ReaderEqual(bytes.NewReader(src), r)
+	cos.Close(r)
+	tassert.Fatalf(t, equal, "%s: the cached object differs from the source", objName)
+}

--- a/ais/tgtfcold.go
+++ b/ais/tgtfcold.go
@@ -6,6 +6,8 @@ package ais
 
 import (
 	"io"
+	"net/http"
+	"strconv"
 
 	"github.com/NVIDIA/aistore/ais/s3"
 	"github.com/NVIDIA/aistore/cmn"
@@ -85,6 +87,67 @@ func (goi *getOI) _cleanup(revert string, lmfh io.Closer, buf []byte, slab *mems
 		s = "[client gone]" // EPIPE, et al.
 	}
 	nlog.InfoDepth(1, ftcg, tag, cname, "err:", s)
+}
+
+// feat.RangeColdGET: object is not in cluster - read the requested byte range directly
+// from the remote backend and transmit it to the user; do not write anything locally.
+// Compare w/ goi.coldStream (that reads and stores the entire object).
+// (under rlock)
+func (goi *getOI) coldRange() (ecode int, err error) {
+	var (
+		t, lom = goi.t, goi.lom
+		oa     *cmn.ObjAttrs
+	)
+	// HEAD remote object: need size to resolve the range and set Content-Range
+	oa, ecode, err = t.HeadCold(lom, goi.req)
+	if err != nil {
+		return ecode, err
+	}
+
+	whdr := goi.w.Header()
+	hrng, ecode, err := goi.rngToHeader(whdr, oa.Size)
+	if err != nil {
+		return ecode, err
+	}
+	if hrng == nil || hrng.Length <= 0 { // (empty range spec, zero-length suffix)
+		return http.StatusRequestedRangeNotSatisfiable, cos.NewErrRangeNotSatisfiable(nil, []string{goi.ranges.Range}, oa.Size)
+	}
+
+	goi.cold, goi.rget = true, true
+	res := t.Backend(lom.Bck()).GetObjReader(goi.ctx, lom, hrng.Start, hrng.Length)
+	if res.Err != nil {
+		if !cos.IsNotExist(res.Err, res.ErrCode) {
+			nlog.Infoln(ftcg, "(range read)", lom.Cname(), res.Err, res.ErrCode)
+		}
+		return res.ErrCode, res.Err
+	}
+
+	// response headers (compare w/ goi.setwhdr and t.headObjS3)
+	lom.SetCustomMD(oa.GetCustomMD())
+	whdr.Set(cos.HdrContentType, cos.ContentBinary)
+	if goi.dpq.isS3 {
+		whdr.Set(cos.HdrContentLength, strconv.FormatInt(hrng.Length, 10))
+		s3.SetS3Headers(whdr, lom)
+	} else {
+		cmn.ToHeader(oa, whdr, hrng.Length)
+	}
+	goi.w.WriteHeader(http.StatusPartialContent)
+
+	// transmit
+	buf, slab := t.gmm.AllocSize(_txsize(hrng.Length))
+	written, erw := cos.CopyBuffer(goi.w, res.R, buf)
+	slab.Free(buf)
+	cos.Close(res.R)
+
+	if erw != nil || written != hrng.Length {
+		if !cos.IsErrRetriableConn(erw) {
+			nlog.Infoln(ftcg, "(range tx)", lom.Cname(), "err:", erw, "written:", written, "expected:", hrng.Length)
+		}
+		return 0, cmn.ErrGetTxBenign // (already committed 206)
+	}
+
+	goi.stats(written)
+	return 0, nil
 }
 
 // NOTE:

--- a/ais/tgtfcold.go
+++ b/ais/tgtfcold.go
@@ -6,8 +6,6 @@ package ais
 
 import (
 	"io"
-	"net/http"
-	"strconv"
 
 	"github.com/NVIDIA/aistore/ais/s3"
 	"github.com/NVIDIA/aistore/cmn"
@@ -87,67 +85,6 @@ func (goi *getOI) _cleanup(revert string, lmfh io.Closer, buf []byte, slab *mems
 		s = "[client gone]" // EPIPE, et al.
 	}
 	nlog.InfoDepth(1, ftcg, tag, cname, "err:", s)
-}
-
-// feat.RangeColdGET: object is not in cluster - read the requested byte range directly
-// from the remote backend and transmit it to the user; do not write anything locally.
-// Compare w/ goi.coldStream (that reads and stores the entire object).
-// (under rlock)
-func (goi *getOI) coldRange() (ecode int, err error) {
-	var (
-		t, lom = goi.t, goi.lom
-		oa     *cmn.ObjAttrs
-	)
-	// HEAD remote object: need size to resolve the range and set Content-Range
-	oa, ecode, err = t.HeadCold(lom, goi.req)
-	if err != nil {
-		return ecode, err
-	}
-
-	whdr := goi.w.Header()
-	hrng, ecode, err := goi.rngToHeader(whdr, oa.Size)
-	if err != nil {
-		return ecode, err
-	}
-	if hrng == nil || hrng.Length <= 0 { // (empty range spec, zero-length suffix)
-		return http.StatusRequestedRangeNotSatisfiable, cos.NewErrRangeNotSatisfiable(nil, []string{goi.ranges.Range}, oa.Size)
-	}
-
-	goi.cold, goi.rget = true, true
-	res := t.Backend(lom.Bck()).GetObjReader(goi.ctx, lom, hrng.Start, hrng.Length)
-	if res.Err != nil {
-		if !cos.IsNotExist(res.Err, res.ErrCode) {
-			nlog.Infoln(ftcg, "(range read)", lom.Cname(), res.Err, res.ErrCode)
-		}
-		return res.ErrCode, res.Err
-	}
-
-	// response headers (compare w/ goi.setwhdr and t.headObjS3)
-	lom.SetCustomMD(oa.GetCustomMD())
-	whdr.Set(cos.HdrContentType, cos.ContentBinary)
-	if goi.dpq.isS3 {
-		whdr.Set(cos.HdrContentLength, strconv.FormatInt(hrng.Length, 10))
-		s3.SetS3Headers(whdr, lom)
-	} else {
-		cmn.ToHeader(oa, whdr, hrng.Length)
-	}
-	goi.w.WriteHeader(http.StatusPartialContent)
-
-	// transmit
-	buf, slab := t.gmm.AllocSize(_txsize(hrng.Length))
-	written, erw := cos.CopyBuffer(goi.w, res.R, buf)
-	slab.Free(buf)
-	cos.Close(res.R)
-
-	if erw != nil || written != hrng.Length {
-		if !cos.IsErrRetriableConn(erw) {
-			nlog.Infoln(ftcg, "(range tx)", lom.Cname(), "err:", erw, "written:", written, "expected:", hrng.Length)
-		}
-		return 0, cmn.ErrGetTxBenign // (already committed 206)
-	}
-
-	goi.stats(written)
-	return 0, nil
 }
 
 // NOTE:

--- a/ais/tgtfrange.go
+++ b/ais/tgtfrange.go
@@ -54,10 +54,10 @@ var rcFilling sync.Map // lom.Uname() => struct{}
 
 type (
 	// a piece of the requested range: `size` bytes at `off`
-	// - path != "":  locally cached chunk
-	// - count > 0:   to read [coff, coff+clen) from the backend and store it as
-	//                chunks [num, num+count) - a single read for the entire run
-	// - otherwise:   to read [off, off+size) from the backend, not storing anything
+	// - path != "": to read from the locally cached chunk
+	// - count > 0:  to read [coff, coff+clen) from the backend and store it as
+	//               chunks [num, num+count) - a single read for the entire run
+	// - otherwise:  to read [off, off+size) from the backend, not storing anything
 	rcseg struct {
 		path       string
 		num, count int
@@ -131,21 +131,7 @@ func (goi *getOI) coldRange() (ecode int, err error) {
 	goi.w.WriteHeader(http.StatusPartialContent)
 
 	// transmit
-	var written int64
-	for i := range segs {
-		if i > 0 {
-			if src, _, err = rc.open(&segs[i]); err != nil {
-				break
-			}
-		}
-		var n int64
-		n, err = rc.tx(&segs[i], src)
-		written += n
-		if err != nil {
-			break
-		}
-	}
-
+	written, err := rc.txAll(segs, src)
 	if err != nil || written != hrng.Length {
 		if !cos.IsErrRetriableConn(err) {
 			nlog.Infoln(ftcg, "(range tx)", lom.Cname(), "err:", err, "written:", written, "expected:", hrng.Length)
@@ -275,6 +261,23 @@ func (rc *rcache) cached(num int, size int64) string {
 	return c.Path()
 }
 
+// transmit all segments (the first one's source is already resolved)
+func (rc *rcache) txAll(segs []rcseg, src rcsrc) (written int64, err error) {
+	for i := range segs {
+		if i > 0 {
+			if src, _, err = rc.open(&segs[i]); err != nil {
+				return written, err
+			}
+		}
+		n, errN := rc.tx(&segs[i], src)
+		written += n
+		if errN != nil {
+			return written, errN
+		}
+	}
+	return written, nil
+}
+
 // resolve the segment's byte source
 func (rc *rcache) open(s *rcseg) (src rcsrc, ecode int, err error) {
 	goi := rc.goi
@@ -283,9 +286,13 @@ func (rc *rcache) open(s *rcseg) (src rcsrc, ecode int, err error) {
 		if errN == nil {
 			return rcsrc{io.NewSectionReader(fh, s.off-s.coff, s.size), fh}, 0, nil
 		}
-		// gone (e.g., removed by space-cleanup) - fall back to the backend
+		// the recorded chunk is gone (e.g., removed by space-cleanup):
+		// read it from the backend and, if filling, store it again
 		nlog.Warningln(ftcg, "(range cache)", s.path, "err:", errN)
-		s.path, s.num = "", 0
+		s.path = ""
+		if rc.filling {
+			s.count = 1
+		}
 	}
 
 	off, size := s.off, s.size
@@ -320,7 +327,7 @@ func (rc *rcache) txStore(s *rcseg, src rcsrc) (int64, error) {
 		goi       = rc.goi
 		lom       = goi.lom
 		cksumType = lom.CksumConf().Type
-		sw        = &sectionWriter{w: goi.w, skip: s.off - s.coff, left: s.size}
+		sw        = &subrangeWriter{w: goi.w, skip: s.off - s.coff, left: s.size}
 		buf, slab = goi.t.gmm.AllocSize(_txsize(rc.chunkSize))
 	)
 	defer slab.Free(buf)
@@ -365,9 +372,9 @@ func (rc *rcache) txStore(s *rcseg, src rcsrc) (int64, error) {
 }
 
 // cannot store: transmit whatever is left of the run
-func (rc *rcache) drain(sw *sectionWriter, src rcsrc, buf []byte, err error) (int64, error) {
-	nlog.Warningln(ftcg, "(range cache)", rc.goi.lom.Cname(), "err:", err)
-	_, err = cos.CopyBuffer(sw, src.r, buf)
+func (rc *rcache) drain(sw *subrangeWriter, src rcsrc, buf []byte, reason error) (int64, error) {
+	nlog.Warningln(ftcg, "(range cache)", rc.goi.lom.Cname(), "err:", reason)
+	_, err := cos.CopyBuffer(sw, src.r, buf)
 	return sw.n, err
 }
 
@@ -400,15 +407,16 @@ func rcID(oa *cmn.ObjAttrs) string {
 	return fmt.Sprintf("%s%016x", rcIDprefix, onexxh.Checksum64S(cos.UnsafeB(s), cos.MLCG32))
 }
 
-// forwards only the [skip, skip+left) sub-range of the stream
-type sectionWriter struct {
+// forwards only the [skip, skip+left) sub-range of the stream, discarding the rest
+// (compare w/ cos.SectionWriter that is io.WriterAt based)
+type subrangeWriter struct {
 	w    io.Writer
 	skip int64
 	left int64
 	n    int64 // forwarded
 }
 
-func (sw *sectionWriter) Write(p []byte) (int, error) {
+func (sw *subrangeWriter) Write(p []byte) (int, error) {
 	l := len(p)
 	if sw.skip > 0 {
 		if int64(l) <= sw.skip {

--- a/ais/tgtfrange.go
+++ b/ais/tgtfrange.go
@@ -1,0 +1,433 @@
+// Package ais provides AIStore's proxy and target nodes.
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package ais
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/NVIDIA/aistore/ais/s3"
+	"github.com/NVIDIA/aistore/cmn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/cmn/nlog"
+	"github.com/NVIDIA/aistore/core"
+
+	onexxh "github.com/OneOfOne/xxhash"
+)
+
+// feat.RangeColdGET: ranged GET of an object that is not present in the cluster.
+//
+// Instead of the full-blown cold GET (that reads and stores the entire object), read
+// the requested byte range from the remote backend and transmit it to the user. On the
+// way out, cache it: the object is mapped onto a fixed grid of chunks; the grid-aligned
+// chunks covering the range are stored and recorded in a _partial_ chunk-manifest
+// (see core.Ufest). Once the grid is fully covered the manifest gets completed - at
+// which point the object becomes a regular (chunked) in-cluster object.
+//
+// Notes:
+// - the grid is fixed: chunk number <=> object offset is a bijection, and so chunks
+//   accumulated out of order and with gaps require no extra metadata
+// - manifest ID is derived from the remote version/ETag: when the source changes so
+//   does the ID, whereby previously accumulated chunks are ignored (and, eventually,
+//   removed by `ais space-cleanup`)
+// - caching is best-effort and gets skipped when: the remote object has no
+//   version/ETag; `validate_cold_get` is on (a ranged read carries no whole-object
+//   checksum to validate); another request is already filling the same object
+//
+// Compare w/ goi.coldStream (feat.StreamingColdGET).
+
+const (
+	// minimum grid granularity (the tradeoff: read amplification vs. chunk count)
+	rcChunkSize = 8 * cos.MiB
+
+	rcIDprefix = "rcget-"
+)
+
+// at most one filling request per object
+var rcFilling sync.Map // lom.Uname() => struct{}
+
+type (
+	// a piece of the requested range: `size` bytes at `off`
+	// - path != "":  locally cached chunk
+	// - count > 0:   to read [coff, coff+clen) from the backend and store it as
+	//                chunks [num, num+count) - a single read for the entire run
+	// - otherwise:   to read [off, off+size) from the backend, not storing anything
+	rcseg struct {
+		path       string
+		num, count int
+		coff, clen int64
+		off, size  int64
+	}
+	rcsrc struct {
+		r  io.Reader
+		cl io.Closer
+	}
+	rcache struct {
+		goi       *getOI
+		u         *core.Ufest // partial manifest; nil when not caching
+		uname     string
+		size      int64 // remote object size
+		chunkSize int64
+		total     int // total chunks in the grid
+		filling   bool
+		added     bool
+	}
+)
+
+// (under rlock)
+func (goi *getOI) coldRange() (ecode int, err error) {
+	var (
+		t, lom = goi.t, goi.lom
+		oa     *cmn.ObjAttrs
+	)
+	// HEAD remote object: need size to resolve the range and set Content-Range
+	oa, ecode, err = t.HeadCold(lom, goi.req)
+	if err != nil {
+		return ecode, err
+	}
+
+	whdr := goi.w.Header()
+	hrng, ecode, err := goi.rngToHeader(whdr, oa.Size)
+	if err != nil {
+		return ecode, err
+	}
+	if hrng == nil || hrng.Length <= 0 { // (empty range spec, zero-length suffix)
+		return http.StatusRequestedRangeNotSatisfiable, cos.NewErrRangeNotSatisfiable(nil, []string{goi.ranges.Range}, oa.Size)
+	}
+
+	goi.cold = true
+	lom.SetCustomMD(oa.GetCustomMD())
+	lom.CopyVersion(oa)
+
+	rc := goi.rcInit(oa)
+	defer rc.fini()
+
+	segs := rc.plan(hrng)
+
+	// resolve the first segment _prior_ to putting the response header on the wire
+	// (to keep reporting backend errors as such)
+	src, ecode, err := rc.open(&segs[0])
+	if err != nil {
+		if !cos.IsNotExist(err, ecode) {
+			nlog.Infoln(ftcg, "(range read)", lom.Cname(), err, ecode)
+		}
+		return ecode, err
+	}
+
+	// response headers (compare w/ goi.setwhdr and t.headObjS3)
+	whdr.Set(cos.HdrContentType, cos.ContentBinary)
+	if goi.dpq.isS3 {
+		whdr.Set(cos.HdrContentLength, strconv.FormatInt(hrng.Length, 10))
+		s3.SetS3Headers(whdr, lom)
+	} else {
+		cmn.ToHeader(oa, whdr, hrng.Length)
+	}
+	goi.w.WriteHeader(http.StatusPartialContent)
+
+	// transmit
+	var written int64
+	for i := range segs {
+		if i > 0 {
+			if src, _, err = rc.open(&segs[i]); err != nil {
+				break
+			}
+		}
+		var n int64
+		n, err = rc.tx(&segs[i], src)
+		written += n
+		if err != nil {
+			break
+		}
+	}
+
+	if err != nil || written != hrng.Length {
+		if !cos.IsErrRetriableConn(err) {
+			nlog.Infoln(ftcg, "(range tx)", lom.Cname(), "err:", err, "written:", written, "expected:", hrng.Length)
+		}
+		return 0, cmn.ErrGetTxBenign // (already committed 206)
+	}
+
+	goi.stats(written)
+	return 0, nil
+}
+
+func (goi *getOI) rcInit(oa *cmn.ObjAttrs) *rcache {
+	var (
+		lom = goi.lom
+		rc  = &rcache{goi: goi, uname: lom.Uname(), size: oa.Size}
+	)
+	if oa.Size <= 0 || lom.ValidateColdGet() {
+		return rc
+	}
+	id := rcID(oa)
+	if id == "" { // cannot tell whether the remote object has changed
+		return rc
+	}
+	u, err := core.NewUfest(id, lom, false /*must-exist*/)
+	if err != nil {
+		nlog.Warningln(ftcg, "(range cache)", lom.Cname(), "err:", err)
+		return rc
+	}
+	if err := u.LoadPartial(lom); err != nil && !cos.IsNotExist(err) {
+		nlog.Warningln(ftcg, "(range cache)", lom.Cname(), "err:", err)
+		return rc
+	}
+
+	rc.u = u
+	rc.chunkSize, rc.total = rcGrid(oa.Size)
+	_, loaded := rcFilling.LoadOrStore(rc.uname, struct{}{})
+	rc.filling = !loaded
+	return rc
+}
+
+// persist the accumulated chunks; when the grid is fully covered, complete the
+// manifest - the object becomes a regular (chunked) object
+func (rc *rcache) fini() {
+	if !rc.filling {
+		return
+	}
+	defer rcFilling.Delete(rc.uname)
+
+	lom := rc.goi.lom
+	if rc.added {
+		if err := rc.u.StorePartial(lom, false /*locked*/); err != nil {
+			nlog.Warningln(ftcg, "(range cache)", lom.Cname(), "err:", err)
+			return
+		}
+	}
+	if rc.u.Count() != rc.total || rc.u.Size() != rc.size {
+		return
+	}
+	if !lom.UpgradeLock() { // (concurrent reader - next time)
+		return
+	}
+	err := rc.complete()
+	lom.DowngradeLock()
+	if err != nil {
+		nlog.Warningln(ftcg, "(range cache complete)", lom.Cname(), "err:", err)
+	}
+}
+
+func (rc *rcache) complete() error {
+	lom := rc.goi.lom
+	if ty := lom.CksumConf().Type; ty != cos.ChecksumNone {
+		cksumH := cos.NewCksumHash(ty)
+		if err := rc.u.ComputeWholeChecksum(cksumH); err != nil {
+			return err
+		}
+		lom.SetCksum(&cksumH.Cksum)
+	}
+	return lom.CompleteUfest(rc.u, true /*locked*/)
+}
+
+// split the requested range into segments (see rcseg), coalescing
+// consecutive not-cached chunks to read them in one shot
+func (rc *rcache) plan(hrng *htrange) []rcseg {
+	end := hrng.Start + hrng.Length
+	if rc.u == nil {
+		return []rcseg{{off: hrng.Start, size: hrng.Length}}
+	}
+	var (
+		first = int(hrng.Start / rc.chunkSize)
+		last  = int((end - 1) / rc.chunkSize)
+		segs  = make([]rcseg, 0, last-first+1)
+	)
+	for i := first; i <= last; i++ {
+		s := rcseg{num: i + 1, coff: int64(i) * rc.chunkSize}
+		s.clen = min(rc.chunkSize, rc.size-s.coff)
+		s.off = max(hrng.Start, s.coff)
+		s.size = min(end, s.coff+s.clen) - s.off
+
+		if s.path = rc.cached(s.num, s.clen); s.path != "" {
+			segs = append(segs, s)
+			continue
+		}
+		if l := len(segs); l > 0 && segs[l-1].path == "" {
+			prev := &segs[l-1] // extend the run
+			prev.clen, prev.size = prev.clen+s.clen, prev.size+s.size
+			if rc.filling {
+				prev.count++
+			}
+			continue
+		}
+		if rc.filling {
+			s.count = 1
+		} else {
+			s.num = 0
+		}
+		segs = append(segs, s)
+	}
+	return segs
+}
+
+// (returning the pathname: the manifest may get modified in-place, see Ufest._add)
+func (rc *rcache) cached(num int, size int64) string {
+	c, err := rc.u.GetChunk(num)
+	if err != nil || c.Size() != size {
+		return ""
+	}
+	return c.Path()
+}
+
+// resolve the segment's byte source
+func (rc *rcache) open(s *rcseg) (src rcsrc, ecode int, err error) {
+	goi := rc.goi
+	if s.path != "" {
+		fh, errN := os.Open(s.path)
+		if errN == nil {
+			return rcsrc{io.NewSectionReader(fh, s.off-s.coff, s.size), fh}, 0, nil
+		}
+		// gone (e.g., removed by space-cleanup) - fall back to the backend
+		nlog.Warningln(ftcg, "(range cache)", s.path, "err:", errN)
+		s.path, s.num = "", 0
+	}
+
+	off, size := s.off, s.size
+	if s.count > 0 {
+		off, size = s.coff, s.clen // caching: read the entire (grid-aligned) run
+	}
+	res := goi.t.Backend(goi.lom.Bck()).GetObjReader(goi.ctx, goi.lom, off, size)
+	if res.Err != nil {
+		return src, res.ErrCode, res.Err
+	}
+	goi.rget = true
+	return rcsrc{res.R, res.R}, 0, nil
+}
+
+// transmit the segment; return the number of bytes transmitted
+func (rc *rcache) tx(s *rcseg, src rcsrc) (int64, error) {
+	goi := rc.goi
+	defer cos.Close(src.cl)
+
+	if s.count > 0 {
+		return rc.txStore(s, src)
+	}
+	buf, slab := goi.t.gmm.AllocSize(_txsize(s.size))
+	written, err := cos.CopyBuffer(goi.w, src.r, buf)
+	slab.Free(buf)
+	return written, err
+}
+
+// transmit the requested sub-range of the run and, at the same time, store its chunks
+func (rc *rcache) txStore(s *rcseg, src rcsrc) (int64, error) {
+	var (
+		goi       = rc.goi
+		lom       = goi.lom
+		cksumType = lom.CksumConf().Type
+		sw        = &sectionWriter{w: goi.w, skip: s.off - s.coff, left: s.size}
+		buf, slab = goi.t.gmm.AllocSize(_txsize(rc.chunkSize))
+	)
+	defer slab.Free(buf)
+
+	for i := range s.count {
+		var (
+			num  = s.num + i
+			coff = s.coff + int64(i)*rc.chunkSize
+			size = min(rc.chunkSize, rc.size-coff)
+		)
+		c, err := rc.u.NewChunk(num, lom)
+		if err != nil {
+			return rc.drain(sw, src, buf, err)
+		}
+		fh, err := lom.CreatePart(c.Path())
+		if err != nil {
+			return rc.drain(sw, src, buf, err)
+		}
+
+		written, cksum, err := cos.CopyAndChecksum(cos.NewWriterMulti(sw, fh), io.LimitReader(src.r, size),
+			buf, cksumType)
+		cos.Close(fh)
+		if err == nil && written != size {
+			err = fmt.Errorf("chunk %d: read %d, expected %d", num, written, size)
+		}
+		if err != nil {
+			if errN := cos.RemoveFile(c.Path()); errN != nil {
+				nlog.Errorln(ftcg, "(range cache)", c.Path(), "err:", errN)
+			}
+			return sw.n, err
+		}
+
+		if cksum != nil {
+			c.SetCksum(&cksum.Cksum)
+		}
+		if err := rc.u.Add(c, written, int64(num)); err != nil {
+			return rc.drain(sw, src, buf, err) // (keep the chunk: it may be recorded already)
+		}
+		rc.added = true
+	}
+	return sw.n, nil
+}
+
+// cannot store: transmit whatever is left of the run
+func (rc *rcache) drain(sw *sectionWriter, src rcsrc, buf []byte, err error) (int64, error) {
+	nlog.Warningln(ftcg, "(range cache)", rc.goi.lom.Cname(), "err:", err)
+	_, err = cos.CopyBuffer(sw, src.r, buf)
+	return sw.n, err
+}
+
+//
+// helpers
+//
+
+// fixed grid, with the granularity adjusted to fit core.MaxChunkCount
+func rcGrid(size int64) (chunkSize int64, total int) {
+	chunkSize = rcChunkSize
+	if l := cos.DivCeil(size, core.MaxChunkCount); l > chunkSize {
+		chunkSize = cos.CeilAlignI64(l, rcChunkSize)
+	}
+	return chunkSize, int(cos.DivCeil(size, chunkSize))
+}
+
+// derive manifest ID from the remote object's version and/or ETag
+// (returns "" when there's neither - ie., when there's no way to tell
+// whether the remote object has changed)
+func rcID(oa *cmn.ObjAttrs) string {
+	var (
+		verMD, _ = oa.GetCustomKey(cmn.VersionObjMD)
+		etag, _  = oa.GetCustomKey(cmn.ETag)
+		ver      = oa.Version() // remote ais: own version (a sequence number)
+	)
+	if verMD == "" && etag == "" && ver == "" {
+		return ""
+	}
+	s := fmt.Sprintf("%s/%s/%s/%d", verMD, etag, ver, oa.Size)
+	return fmt.Sprintf("%s%016x", rcIDprefix, onexxh.Checksum64S(cos.UnsafeB(s), cos.MLCG32))
+}
+
+// forwards only the [skip, skip+left) sub-range of the stream
+type sectionWriter struct {
+	w    io.Writer
+	skip int64
+	left int64
+	n    int64 // forwarded
+}
+
+func (sw *sectionWriter) Write(p []byte) (int, error) {
+	l := len(p)
+	if sw.skip > 0 {
+		if int64(l) <= sw.skip {
+			sw.skip -= int64(l)
+			return l, nil
+		}
+		p, sw.skip = p[sw.skip:], 0
+	}
+	if int64(len(p)) > sw.left {
+		p = p[:sw.left]
+	}
+	if len(p) == 0 {
+		return l, nil
+	}
+	n, err := sw.w.Write(p)
+	sw.left -= int64(n)
+	sw.n += int64(n)
+	if err != nil {
+		return l - len(p) + n, err
+	}
+	return l, nil
+}

--- a/ais/tgtfrange_internal_test.go
+++ b/ais/tgtfrange_internal_test.go
@@ -1,0 +1,118 @@
+// Package ais: internal unit tests
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package ais
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/NVIDIA/aistore/cmn"
+	"github.com/NVIDIA/aistore/cmn/cos"
+	"github.com/NVIDIA/aistore/core"
+	"github.com/NVIDIA/aistore/tools/tassert"
+)
+
+func TestRcGrid(t *testing.T) {
+	tests := []struct {
+		size      int64
+		chunkSize int64
+		total     int
+	}{
+		{size: 1, chunkSize: rcChunkSize, total: 1},
+		{size: rcChunkSize, chunkSize: rcChunkSize, total: 1},
+		{size: rcChunkSize + 1, chunkSize: rcChunkSize, total: 2},
+		{size: 10 * cos.GiB, chunkSize: rcChunkSize, total: 1280},
+		// beyond core.MaxChunkCount chunks: granularity adjusted
+		{size: 1 * cos.TiB, chunkSize: 112 * cos.MiB, total: 9363},
+	}
+	for _, test := range tests {
+		chunkSize, total := rcGrid(test.size)
+		tassert.Errorf(t, chunkSize == test.chunkSize && total == test.total,
+			"size %d: expected (%d, %d), got (%d, %d)", test.size, test.chunkSize, test.total, chunkSize, total)
+		tassert.Errorf(t, total <= core.MaxChunkCount, "size %d: too many chunks (%d)", test.size, total)
+	}
+}
+
+func TestRcID(t *testing.T) {
+	var oa cmn.ObjAttrs
+	oa.Size = 1024
+	tassert.Errorf(t, rcID(&oa) == "", "expected no ID when there's neither version nor ETag")
+
+	oa.SetVersion("1") // remote ais
+	id := rcID(&oa)
+	tassert.Fatalf(t, cos.ValidateManifestID(id) == nil, "invalid manifest ID %q", id)
+	oa.SetVersion("2")
+	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote object changes")
+
+	oa.SetVersion("")
+	oa.SetCustomKey(cmn.ETag, "abc")
+	id = rcID(&oa)
+	tassert.Fatalf(t, cos.ValidateManifestID(id) == nil, "invalid manifest ID %q", id)
+	oa.SetCustomKey(cmn.ETag, "xyz")
+	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote object changes")
+}
+
+func TestRcPlan(t *testing.T) {
+	u, err := core.NewUfest("rcget-0123456789abcdef", nil, false /*must-exist*/)
+	tassert.CheckFatal(t, err)
+
+	rc := &rcache{u: u, size: 3*rcChunkSize + 100, chunkSize: rcChunkSize, total: 4}
+	ranges := []htrange{
+		{Start: 0, Length: 1},                                 // first chunk
+		{Start: 3 * rcChunkSize, Length: 100},                 // last (partial) chunk
+		{Start: rcChunkSize - 10, Length: 20},                 // across a chunk boundary
+		{Start: rcChunkSize - 10, Length: 2*rcChunkSize + 20}, // unaligned, 4 chunks
+		{Start: 0, Length: rc.size},                           // entire object
+	}
+	// nothing is cached: expecting a single (coalesced) segment in either case
+	for _, filling := range []bool{false, true} {
+		rc.filling = filling
+		for _, hrng := range ranges {
+			segs := rc.plan(&hrng)
+			tassert.Fatalf(t, len(segs) == 1, "filling=%t, %+v: expected 1 segment, got %d", filling, hrng, len(segs))
+
+			s := segs[0]
+			tassert.Errorf(t, s.off == hrng.Start && s.size == hrng.Length,
+				"filling=%t, %+v: unexpected sub-range %+v", filling, hrng, s)
+			if !filling {
+				tassert.Errorf(t, s.count == 0, "filling=%t, %+v: not expecting to store %+v", filling, hrng, s)
+				continue
+			}
+			// the run must be grid-aligned and must cover the requested sub-range
+			last := int((hrng.Start + hrng.Length - 1) / rcChunkSize)
+			tassert.Errorf(t, s.num == int(hrng.Start/rcChunkSize)+1 && s.count == last-s.num+2,
+				"%+v: unexpected chunk run %+v", hrng, s)
+			tassert.Errorf(t, s.coff == int64(s.num-1)*rcChunkSize && s.coff+s.clen == min(rc.size, int64(last+1)*rcChunkSize),
+				"%+v: unexpected run extent %+v", hrng, s)
+			tassert.Errorf(t, s.off >= s.coff && s.off+s.size <= s.coff+s.clen,
+				"%+v: sub-range not within the run %+v", hrng, s)
+		}
+	}
+}
+
+func TestSectionWriter(t *testing.T) {
+	const (
+		l    = 100
+		skip = 30
+		size = 50
+	)
+	src := make([]byte, l)
+	for i := range src {
+		src[i] = byte(i)
+	}
+	for _, chunk := range []int{1, 7, l} {
+		var (
+			w  bytes.Buffer
+			sw = &sectionWriter{w: &w, skip: skip, left: size}
+		)
+		for off := 0; off < l; off += chunk {
+			n, err := sw.Write(src[off:min(off+chunk, l)])
+			tassert.CheckFatal(t, err)
+			tassert.Fatalf(t, n == min(off+chunk, l)-off, "short write: %d", n)
+		}
+		tassert.Errorf(t, sw.n == size, "expected %d forwarded bytes, got %d", size, sw.n)
+		tassert.Errorf(t, bytes.Equal(w.Bytes(), src[skip:skip+size]), "wrong sub-range (piece size %d)", chunk)
+	}
+}

--- a/ais/tgtfrange_internal_test.go
+++ b/ais/tgtfrange_internal_test.go
@@ -24,14 +24,22 @@ func TestRcGrid(t *testing.T) {
 		{size: rcChunkSize, chunkSize: rcChunkSize, total: 1},
 		{size: rcChunkSize + 1, chunkSize: rcChunkSize, total: 2},
 		{size: 10 * cos.GiB, chunkSize: rcChunkSize, total: 1280},
-		// beyond core.MaxChunkCount chunks: granularity adjusted
+		{size: core.MaxChunkCount * rcChunkSize, chunkSize: rcChunkSize, total: core.MaxChunkCount},
+		// beyond core.MaxChunkCount chunks: granularity gets adjusted
+		{size: core.MaxChunkCount*rcChunkSize + 1, chunkSize: 2 * rcChunkSize, total: 5000},
 		{size: 1 * cos.TiB, chunkSize: 112 * cos.MiB, total: 9363},
 	}
 	for _, test := range tests {
 		chunkSize, total := rcGrid(test.size)
 		tassert.Errorf(t, chunkSize == test.chunkSize && total == test.total,
 			"size %d: expected (%d, %d), got (%d, %d)", test.size, test.chunkSize, test.total, chunkSize, total)
-		tassert.Errorf(t, total <= core.MaxChunkCount, "size %d: too many chunks (%d)", test.size, total)
+	}
+	// the grid must always fit MaxChunkCount and must always cover the object
+	for _, size := range []int64{1, 63, rcChunkSize - 1, 7 * cos.GiB, 977 * cos.GiB, 64 * cos.TiB, 1024 * cos.TiB} {
+		chunkSize, total := rcGrid(size)
+		tassert.Errorf(t, total > 0 && total <= core.MaxChunkCount, "size %d: invalid chunk count %d", size, total)
+		tassert.Errorf(t, int64(total-1)*chunkSize < size && int64(total)*chunkSize >= size,
+			"size %d: grid (%d, %d) does not cover the object", size, chunkSize, total)
 	}
 }
 
@@ -43,15 +51,20 @@ func TestRcID(t *testing.T) {
 	oa.SetVersion("1") // remote ais
 	id := rcID(&oa)
 	tassert.Fatalf(t, cos.ValidateManifestID(id) == nil, "invalid manifest ID %q", id)
+	tassert.Errorf(t, rcID(&oa) == id, "ID must be stable")
 	oa.SetVersion("2")
-	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote object changes")
+	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote version changes")
 
 	oa.SetVersion("")
 	oa.SetCustomKey(cmn.ETag, "abc")
 	id = rcID(&oa)
 	tassert.Fatalf(t, cos.ValidateManifestID(id) == nil, "invalid manifest ID %q", id)
 	oa.SetCustomKey(cmn.ETag, "xyz")
-	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote object changes")
+	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote ETag changes")
+
+	id = rcID(&oa)
+	oa.Size++
+	tassert.Errorf(t, rcID(&oa) != id, "ID must change when the remote size changes")
 }
 
 func TestRcPlan(t *testing.T) {
@@ -92,27 +105,35 @@ func TestRcPlan(t *testing.T) {
 	}
 }
 
-func TestSectionWriter(t *testing.T) {
-	const (
-		l    = 100
-		skip = 30
-		size = 50
-	)
+func TestSubrangeWriter(t *testing.T) {
+	const l = 100
 	src := make([]byte, l)
 	for i := range src {
 		src[i] = byte(i)
 	}
-	for _, chunk := range []int{1, 7, l} {
-		var (
-			w  bytes.Buffer
-			sw = &sectionWriter{w: &w, skip: skip, left: size}
-		)
-		for off := 0; off < l; off += chunk {
-			n, err := sw.Write(src[off:min(off+chunk, l)])
-			tassert.CheckFatal(t, err)
-			tassert.Fatalf(t, n == min(off+chunk, l)-off, "short write: %d", n)
+	tests := []struct{ skip, size int64 }{
+		{skip: 0, size: l},   // all of it
+		{skip: 0, size: 10},  // head
+		{skip: 90, size: 10}, // tail
+		{skip: 30, size: 50}, // middle
+		{skip: 99, size: 1},  // single byte
+		{skip: l, size: 0},   // nothing
+	}
+	for _, test := range tests {
+		for _, piece := range []int{1, 7, l} { // write in variable-size pieces
+			var (
+				w  bytes.Buffer
+				sw = &subrangeWriter{w: &w, skip: test.skip, left: test.size}
+			)
+			for off := 0; off < l; off += piece {
+				end := min(off+piece, l)
+				n, err := sw.Write(src[off:end])
+				tassert.CheckFatal(t, err)
+				tassert.Fatalf(t, n == end-off, "%+v: short write %d (expecting %d)", test, n, end-off)
+			}
+			tassert.Errorf(t, sw.n == test.size, "%+v: forwarded %d bytes", test, sw.n)
+			tassert.Errorf(t, bytes.Equal(w.Bytes(), src[test.skip:test.skip+test.size]),
+				"%+v: wrong sub-range (piece size %d)", test, piece)
 		}
-		tassert.Errorf(t, sw.n == size, "expected %d forwarded bytes, got %d", size, sw.n)
-		tassert.Errorf(t, bytes.Equal(w.Bytes(), src[skip:skip+size]), "wrong sub-range (piece size %d)", chunk)
 	}
 }

--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -741,6 +741,12 @@ do: // retry uplock or ec-recovery, the latter only once
 		// TODO: utilize res.ObjAttrs
 	}
 
+	// feat.RangeColdGET (object is not in cluster): read the requested range
+	// directly from remote backend - do not run full-blown cold-GET, do not store
+	if cold && !goi.verchanged && goi.ranges.Range != "" && goi.lom.IsFeatureSet(feat.RangeColdGET) {
+		return goi.coldRange()
+	}
+
 	// validate checksums and recover (a.k.a. self-heal) if corrupted
 	if !cold && goi.lom.ValidateWarmGet() {
 		cold, ecode, err = goi.validateRecover()

--- a/ais/tgtobj.go
+++ b/ais/tgtobj.go
@@ -741,8 +741,8 @@ do: // retry uplock or ec-recovery, the latter only once
 		// TODO: utilize res.ObjAttrs
 	}
 
-	// feat.RangeColdGET (object is not in cluster): read the requested range
-	// directly from remote backend - do not run full-blown cold-GET, do not store
+	// feat.RangeColdGET (object is not in cluster): read the requested range directly
+	// from remote backend (and cache it, chunk by chunk) - no full-blown cold-GET
 	if cold && !goi.verchanged && goi.ranges.Range != "" && goi.lom.IsFeatureSet(feat.RangeColdGET) {
 		return goi.coldRange()
 	}

--- a/cmd/cli/cli/feat.go
+++ b/cmd/cli/cli/feat.go
@@ -53,7 +53,7 @@ var clusterFeatDesc = [...]string{
 	"publish selected Go runtime metrics via Prometheus",
 	"allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked",
 	"allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)",
-	"serve range read of a missing (not-cached) object directly from remote backend, do not store the object",
+	"serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges",
 
 	// apc.ResetToken ("none") ===========
 }

--- a/cmd/cli/cli/feat.go
+++ b/cmd/cli/cli/feat.go
@@ -53,6 +53,7 @@ var clusterFeatDesc = [...]string{
 	"publish selected Go runtime metrics via Prometheus",
 	"allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked",
 	"allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)",
+	"serve range read of a missing (not-cached) object directly from remote backend, do not store the object",
 
 	// apc.ResetToken ("none") ===========
 }
@@ -87,6 +88,7 @@ var featTags = map[string]string{
 	"Enable-Go-Runtime-Metrics":            "telemetry,ops,overhead",
 	"Dload-Allow-Private-Egress":           "security-",
 	"S3-Redirect-Rebuild":                  "s3,compat,security-",
+	"Range-Cold-GET":                       "perf,integrity-",
 }
 
 // common (cluster, bucket) feature-flags (set, show) helper

--- a/cmn/feat/feat.go
+++ b/cmn/feat/feat.go
@@ -54,6 +54,7 @@ const (
 	EnableGoRuntimeMetrics    // publish selected Go runtime metrics via Prometheus
 	DloadAllowPrivateEgress   // allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 	S3RedirectRebuild         // allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
+	RangeColdGET              // serve range read of a missing (not-cached) object directly from remote backend, do not store the object
 )
 
 var Cluster = [...]string{
@@ -85,6 +86,7 @@ var Cluster = [...]string{
 	"Enable-Go-Runtime-Metrics",
 	"Dload-Allow-Private-Egress",
 	"S3-Redirect-Rebuild",
+	"Range-Cold-GET",
 
 	// apc.ResetToken ("none") ===========
 }
@@ -99,6 +101,7 @@ var Bucket = [...]string{
 	"S3-ListObjectVersions",
 	"Resume-Interrupted-MPU",
 	"Count-Object-NotFound-Stats",
+	"Range-Cold-GET",
 
 	// apc.ResetToken ("none") ===========
 }

--- a/cmn/feat/feat.go
+++ b/cmn/feat/feat.go
@@ -54,7 +54,7 @@ const (
 	EnableGoRuntimeMetrics    // publish selected Go runtime metrics via Prometheus
 	DloadAllowPrivateEgress   // allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 	S3RedirectRebuild         // allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
-	RangeColdGET              // serve range read of a missing (not-cached) object directly from remote backend, do not store the object
+	RangeColdGET              // serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges
 )
 
 var Cluster = [...]string{

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -80,7 +80,7 @@ The validation occurs both at the cluster level and when setting bucket properti
 | `Enable-Go-Runtime-Metrics` | `telemetry,ops,overhead` | publish a low-cardinality subset of Go runtime metrics (goroutines, GC, heap) via Prometheus |
 | `Dload-Allow-Private-Egress` | `security-` | allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked |
 | `S3-Redirect-Rebuild` | `s3,compat,security-` | allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured) |
-| `Range-Cold-GET` | `perf,integrity-` | serve range read of a missing (not-cached) object directly from remote backend, do not store the object |
+| `Range-Cold-GET` | `perf,integrity-` | serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges |
 
 ## Global features
 
@@ -138,7 +138,7 @@ Count-Object-NotFound-Stats          telemetry,ops          count GET(object) 40
 Enable-Go-Runtime-Metrics            telemetry,ops,overhead publish selected Go runtime metrics via Prometheus
 Dload-Allow-Private-Egress           security-              allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 S3-Redirect-Rebuild                  s3,compat,security-    allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
-Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
+Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges
 
 Cluster config updated
 ```
@@ -186,7 +186,7 @@ Count-Object-NotFound-Stats          telemetry,ops          count GET(object) 40
 Enable-Go-Runtime-Metrics            telemetry,ops,overhead publish selected Go runtime metrics via Prometheus
 Dload-Allow-Private-Egress           security-              allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 S3-Redirect-Rebuild                  s3,compat,security-    allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
-Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
+Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges
 ```
 
 The same in JSON:
@@ -249,7 +249,7 @@ S3-Use-Path-Style                s3,compat              use older path-style add
 Resume-Interrupted-MPU           mpu,ops                resume interrupted multipart uploads from persisted partial manifests
 S3-ListObjectVersions            s3,overhead            when versioning info is requested, use ListObjectVersions API (beware: extremely slow, versioned S3 buckets only)
 Count-Object-NotFound-Stats      telemetry,ops          count GET(object) 404 as errors
-Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
+Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges
 ```
 
 #### 3. reset feature flags back to zero (or 'none')
@@ -270,7 +270,7 @@ S3-Use-Path-Style                s3,compat              use older path-style add
 Resume-Interrupted-MPU           mpu,ops                resume interrupted multipart uploads from persisted partial manifests
 S3-ListObjectVersions            s3,overhead            when versioning info is requested, use ListObjectVersions API (beware: extremely slow, versioned S3 buckets only)
 Count-Object-NotFound-Stats      telemetry,ops          count GET(object) 404 as errors
-Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
+Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, caching the accumulated ranges
 ```
 
 ### Validation errors

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -80,6 +80,7 @@ The validation occurs both at the cluster level and when setting bucket properti
 | `Enable-Go-Runtime-Metrics` | `telemetry,ops,overhead` | publish a low-cardinality subset of Go runtime metrics (goroutines, GC, heap) via Prometheus |
 | `Dload-Allow-Private-Egress` | `security-` | allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked |
 | `S3-Redirect-Rebuild` | `s3,compat,security-` | allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured) |
+| `Range-Cold-GET` | `perf,integrity-` | serve range read of a missing (not-cached) object directly from remote backend, do not store the object |
 
 ## Global features
 
@@ -94,8 +95,8 @@ Fsync-PUT                              S3-Use-Path-Style                      Co
 LZ4-Block-1MB                          Do-not-Delete-When-Rebalancing         Enable-Go-Runtime-Metrics
 LZ4-Frame-Checksum                     Do-not-Set-Control-Plane-ToS           Dload-Allow-Private-Egress
 Do-not-Allow-Passing-FQN-to-ETL        Trust-Crypto-Safe-Checksums            S3-Redirect-Rebuild
-Ignore-LimitedCoexistence-Conflicts    S3-ListObjectVersions                  none
-S3-Presigned-Request                   Enable-Detailed-Prom-Metrics
+Ignore-LimitedCoexistence-Conflicts    S3-ListObjectVersions                  Range-Cold-GET
+S3-Presigned-Request                   Enable-Detailed-Prom-Metrics           none
 ```
 
 For example:
@@ -137,6 +138,7 @@ Count-Object-NotFound-Stats          telemetry,ops          count GET(object) 40
 Enable-Go-Runtime-Metrics            telemetry,ops,overhead publish selected Go runtime metrics via Prometheus
 Dload-Allow-Private-Egress           security-              allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 S3-Redirect-Rebuild                  s3,compat,security-    allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
+Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
 
 Cluster config updated
 ```
@@ -184,6 +186,7 @@ Count-Object-NotFound-Stats          telemetry,ops          count GET(object) 40
 Enable-Go-Runtime-Metrics            telemetry,ops,overhead publish selected Go runtime metrics via Prometheus
 Dload-Allow-Private-Egress           security-              allow downloader egress to private RFC1918/ULA addresses; loopback and link-local remain blocked
 S3-Redirect-Rebuild                  s3,compat,security-    allow S3 clients that rebuild redirected requests instead of following the Location URI (forbidden when AuthN or intra-cluster signing is configured)
+Range-Cold-GET                       perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
 ```
 
 The same in JSON:
@@ -222,8 +225,8 @@ Here's a brief 1-2-3 demonstration in re specifically: feature flags.
 $ ais bucket props set ais://nnn features <TAB-TAB>
 
 Skip-Loading-VersionChecksum-MD   Streaming-Cold-GET                Count-Object-NotFound-Stats
-Fsync-PUT                         S3-Use-Path-Style                 none
-S3-Presigned-Request              S3-ListObjectVersions
+Fsync-PUT                         S3-Use-Path-Style                 Range-Cold-GET
+S3-Presigned-Request              S3-ListObjectVersions             none
 Disable-Cold-GET                  Resume-Interrupted-MPU
 ```
 
@@ -246,6 +249,7 @@ S3-Use-Path-Style                s3,compat              use older path-style add
 Resume-Interrupted-MPU           mpu,ops                resume interrupted multipart uploads from persisted partial manifests
 S3-ListObjectVersions            s3,overhead            when versioning info is requested, use ListObjectVersions API (beware: extremely slow, versioned S3 buckets only)
 Count-Object-NotFound-Stats      telemetry,ops          count GET(object) 404 as errors
+Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
 ```
 
 #### 3. reset feature flags back to zero (or 'none')
@@ -266,6 +270,7 @@ S3-Use-Path-Style                s3,compat              use older path-style add
 Resume-Interrupted-MPU           mpu,ops                resume interrupted multipart uploads from persisted partial manifests
 S3-ListObjectVersions            s3,overhead            when versioning info is requested, use ListObjectVersions API (beware: extremely slow, versioned S3 buckets only)
 Count-Object-NotFound-Stats      telemetry,ops          count GET(object) 404 as errors
+Range-Cold-GET                   perf,integrity-        serve range read of a missing (not-cached) object directly from remote backend, do not store the object
 ```
 
 ### Validation errors


### PR DESCRIPTION
Fixes #348.

A ranged GET of an object that is not in the cluster currently runs the regular cold GET: the whole object gets downloaded and finalized before the range is served from the local copy, so time-to-first-byte scales with the object size and the cluster pays disk and egress for data nobody asked for.

With the new `Range-Cold-GET` flag (cluster- and bucket-scope) the target HEADs the remote object, reads only the requested bytes via the backend's ranged `GetObjReader`, and streams them back with 206 - staying under rlock, so concurrent range reads of the same missing object don't serialize on the cold-GET write lock. Clients see the usual range semantics either way: the same `Range` request and 206/`Content-Range` response, on both the native and `/s3` routes; the flag only changes what the cluster does behind it.

The bytes are cached on the way out. The object is mapped onto a fixed grid (8MiB, coarser for objects that would otherwise exceed `MaxChunkCount` chunks); the chunks covering the range are stored in a partial chunk-manifest (`core.Ufest`), later reads use whatever has accumulated, and once the grid is dense the manifest is completed and the object becomes a regular chunked object. This needs no changes to the chunked-object machinery: a partial manifest already persists, already takes chunks out of order and already tolerates gaps, and the density and size invariants are only enforced on completion. The manifest ID is derived from the remote version/ETag, so chunks from two versions can never be mixed.

Hence `perf,integrity-`, same as `Streaming-Cold-GET`: a small range pulls its whole grid chunk when caching, and completion re-reads the local chunks once to compute the whole-object checksum. Caching is skipped, though the range is still served, when the remote object has no version/ETag or `validate_cold_get` is enabled.

Tests in `ais/test/range_coldget_test.go` (gated on a remote AIS cluster, which `test-short` deploys) plus unit tests for the grid math and range splitting. Docs updated in `docs/feature_flags.md`.
