### PR TITLE
k8s: retry startup Pod query with backoff instead of fatal exit

### DIFF
--- a/cmn/k8s/k8s.go
+++ b/cmn/k8s/k8s.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/NVIDIA/aistore/api/env"
 	"github.com/NVIDIA/aistore/cmn/cos"
@@ -16,6 +17,8 @@ import (
 	"github.com/NVIDIA/aistore/cmn/nlog"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 type PodStatus struct {
@@ -45,6 +48,14 @@ var (
 	ErrK8sRequired = errors.New("the operation requires Kubernetes")
 )
 
+// initial Pod query backoff: 1s doubling up to 30s cap, ~2.5 min total
+var podQueryBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   2,
+	Cap:      30 * time.Second,
+	Steps:    10,
+}
+
 func Init() {
 	_initClient()
 	client, err := GetClient()
@@ -72,8 +83,15 @@ func Init() {
 		return
 	}
 
-	// Check Pod.
-	pod, err = client.Pod(podName)
+	// Check Pod. Retry with backoff: a transient failure to reach the API server
+	// at startup (e.g., node-local networking not yet ready) must not turn into
+	// a fatal exit and a kubelet crash-loop.
+	err = retry.OnError(podQueryBackoff, func(error) bool { return true }, func() (e error) {
+		if pod, e = client.Pod(podName); e != nil {
+			nlog.Warningln("failed to get Pod", podName, "- will retry:", e)
+		}
+		return e
+	})
 	if err != nil {
 		cos.ExitLogf("Failed to get Pod %q, err: %v", podName, err)
 		return


### PR DESCRIPTION
### Problem

During startup in a Kubernetes deployment, `k8s.Init()` queries the API server
for the node's own Pod. Any error in that single query is treated as fatal
(`cos.ExitLogf`), so a transient, node-local connectivity failure -- for
example, pod networking briefly going down while the container runtime
restarts (`dial tcp 10.96.0.1:443: connect: network is unreachable`) -- kills
the aisnode process with exit code 1.

Once that happens, kubelet restarts the pod under CrashLoopBackOff, with
restart delays doubling from 10s up to 5m. A network blip that lasts about a
minute can therefore keep storage nodes down for several additional minutes,
and when the blip is fleet-wide (e.g., a rolling container-runtime upgrade),
every target in the cluster crash-loops at once.

### Fix

Retry the initial Pod query with exponential backoff before giving up:
1s doubling per attempt, capped at 30s, 10 attempts total (roughly 2.5 minutes
worst case). Each failed attempt is logged as a warning; once retries are
exhausted, the existing fatal-exit behavior is preserved unchanged.

The retry uses `k8s.io/client-go/util/retry.OnError` with a
`k8s.io/apimachinery/pkg/util/wait.Backoff` -- both already in the dependency
tree (`ext/etl` uses the same `wait` machinery). `cmn.RetryArgs` was
considered but is not usable here: package `cmn` imports `cmn/k8s`, so
`cmn/k8s` cannot import `cmn` back.

### Testing

- `go build ./...` and `go vet ./cmn/...` pass (Go 1.26); `gofmt -l` clean.
- `make lint` (golangci-lint v2.12.2): 0 issues; `make spell-check` clean.
- Behavior unchanged when the first query succeeds (the common case) and for
  non-Kubernetes deployments (client init still short-circuits earlier).
