### PR TITLE
k8s: resolve node name from MY_NODE, drop the startup Pod query

### DIFF
--- a/cmn/k8s/k8s.go
+++ b/cmn/k8s/k8s.go
@@ -1,6 +1,6 @@
 // Package k8s: initialization, client, and misc. helpers
 /*
- * Copyright (c) 2018-2025, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
  */
 package k8s
 
@@ -14,8 +14,6 @@ import (
 	"github.com/NVIDIA/aistore/cmn/cos"
 	"github.com/NVIDIA/aistore/cmn/debug"
 	"github.com/NVIDIA/aistore/cmn/nlog"
-
-	v1 "k8s.io/api/core/v1"
 )
 
 type PodStatus struct {
@@ -47,62 +45,37 @@ var (
 
 func Init() {
 	_initClient()
-	client, err := GetClient()
-	if err != nil {
+	if _, err := GetClient(); err != nil {
 		nlog.Infoln(nonK8s, "(init k8s-client returned: '"+_short(err)+"')")
 		return
 	}
-
-	var (
-		pod     *v1.Pod
-		podName = os.Getenv(env.AisK8sPod)
-	)
-	if podName != "" {
-		debug.Func(func() {
-			pn := os.Getenv(defaultPodNameEnv)
-			debug.Assertf(pn == "" || pn == podName, "%q vs %q", pn, podName)
-		})
-	} else {
-		podName = os.Getenv(defaultPodNameEnv)
-	}
-	nlog.Infof("Checking pod: %q", podName)
-
+	podName := _podName()
 	if podName == "" {
 		nlog.Infof("Env %q is not set => %s", env.AisK8sPod, nonK8s)
 		return
 	}
-
-	// Check Pod.
-	pod, err = client.Pod(podName)
-	if err != nil {
-		cos.ExitLogf("Failed to get Pod %q, err: %v", podName, err)
-		return
-	}
-
-	// Check if pod is already scheduled or fall back to env var
-	switch {
-	case pod.Spec.NodeName != "":
-		NodeName = pod.Spec.NodeName
-	case os.Getenv(env.AisK8sNode) != "":
-		NodeName = os.Getenv(env.AisK8sNode)
-	default:
-		cos.ExitLogf("Failed to get K8s node name. %q is not set", env.AisK8sNode)
-		return
-	}
-
-	nlog.Infoln("Pod info:", "name", podName, ",namespace", pod.Namespace, ",node", NodeName, ",hostname", pod.Spec.Hostname, ",host_network", pod.Spec.HostNetwork)
-	_ppvols(pod.Spec.Volumes)
+	_initNode()
+	nlog.Infoln("Pod info:", "name", podName, ",namespace", _namespace(), ",node", NodeName)
 }
 
-func _ppvols(volumes []v1.Volume) {
-	for i := range volumes {
-		name := "  " + volumes[i].Name
-		if claim := volumes[i].VolumeSource.PersistentVolumeClaim; claim != nil {
-			nlog.Infof("%s (%v)", name, claim)
-		} else {
-			nlog.Infoln(name)
-		}
+// Resolve this node's name from the environment.
+func _initNode() {
+	if NodeName = os.Getenv(env.AisK8sNode); NodeName == "" {
+		cos.ExitLogf("Failed to get K8s node name: env %q is not set", env.AisK8sNode)
 	}
+}
+
+// Resolve this pod's name from the environment (empty when not in a pod).
+func _podName() string {
+	podName := os.Getenv(env.AisK8sPod)
+	if podName == "" {
+		return os.Getenv(defaultPodNameEnv)
+	}
+	debug.Func(func() {
+		pn := os.Getenv(defaultPodNameEnv)
+		debug.Assertf(pn == "" || pn == podName, "%q vs %q", pn, podName)
+	})
+	return podName
 }
 
 func IsK8s() bool { return NodeName != "" }

--- a/cmn/k8s/k8s_internal_test.go
+++ b/cmn/k8s/k8s_internal_test.go
@@ -1,0 +1,50 @@
+// Package k8s: initialization, client, and misc. helpers
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package k8s
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aistore/api/env"
+)
+
+func TestInitNodeFromEnv(t *testing.T) {
+	t.Cleanup(func() { NodeName = "" })
+	NodeName = ""
+	t.Setenv(env.AisK8sNode, "env-node")
+
+	_initNode()
+	if NodeName != "env-node" {
+		t.Fatalf("expected NodeName %q, got %q", "env-node", NodeName)
+	}
+	if !IsK8s() {
+		t.Fatal("expected IsK8s() to be true")
+	}
+}
+
+func TestPodName(t *testing.T) {
+	t.Setenv(env.AisK8sPod, "ais-target-0")
+	t.Setenv(defaultPodNameEnv, "ais-target-0")
+	if pn := _podName(); pn != "ais-target-0" {
+		t.Fatalf("expected pod name %q, got %q", "ais-target-0", pn)
+	}
+}
+
+// MY_POD is unset in the dev/k8s proxy statefulset; HOSTNAME carries the pod name there.
+func TestPodNameFromHostname(t *testing.T) {
+	t.Setenv(env.AisK8sPod, "")
+	t.Setenv(defaultPodNameEnv, "ais-proxy-0")
+	if pn := _podName(); pn != "ais-proxy-0" {
+		t.Fatalf("expected pod name %q, got %q", "ais-proxy-0", pn)
+	}
+}
+
+func TestPodNameNonK8s(t *testing.T) {
+	t.Setenv(env.AisK8sPod, "")
+	t.Setenv(defaultPodNameEnv, "")
+	if pn := _podName(); pn != "" {
+		t.Fatalf("expected empty pod name, got %q", pn)
+	}
+}

--- a/docs/environment-vars.md
+++ b/docs/environment-vars.md
@@ -169,7 +169,7 @@ See also:
 | name | comment |
 | ---- | ------- |
 | `MY_POD` and `HOSTNAME` | Kubernetes POD name. `MY_POD` is used in [production](https://github.com/NVIDIA/ais-k8s/blob/main/operator/pkg/resources/cmn/env.go); `HOSTNAME`, on the other hand, is usually considered a Kubernetes default |
-| `MY_NODE` | Kubernetes node name |
+| `MY_NODE` | Kubernetes node name; injected via the downward API in both [production](https://github.com/NVIDIA/ais-k8s/blob/main/operator/pkg/resources/cmn/env.go) and development, and required in Kubernetes deployments - aisnode exits at startup when it is not set |
 | `K8S_NS` and `POD_NAMESPACE` | Kubernetes namespace. `K8S_NS` is used in [production](https://github.com/NVIDIA/ais-k8s/blob/main/operator/pkg/resources/cmn/env.go), while `POD_NAMESPACE` - development |
 
 Kubernetes POD name is also reported via `ais show cluster` CLI - when it is a Kubernetes deployment, e.g.:

--- a/docs/monitoring-logs.md
+++ b/docs/monitoring-logs.md
@@ -233,10 +233,7 @@ I 18:06:18.785011 {aws.head.n:114227,aws.head.ns.total:16799090100532,del.n:109,
 In Kubernetes deployments, AIS logs include pod and cluster-specific details:
 
 ```
-I 19:28:24.786264 k8s:93 Pod info: name ais-proxy-15 ,namespace ais ,node 10.49.41.55 ,hostname ais-proxy-15 ,host_network false
-I 19:28:24.786281 k8s:101   ais-ais-state (&PersistentVolumeClaimVolumeSource{ClaimName:ais-ais-state-ais-proxy-15,ReadOnly:false,})
-I 19:28:24.786304 k8s:103   config-template
-I 19:28:24.786306 k8s:103   config-mount
+I 19:28:24.786264 k8s:58 Pod info: name ais-proxy-15 ,namespace ais ,node 10.49.41.55
 ```
 
 ## Key Performance Metrics


### PR DESCRIPTION
On startup, `k8s.Init()` queries the API server for the node's own Pod (`client.Pod(podName)`) and calls `cos.ExitLogf` on any error. The only piece of information consumed from the returned Pod spec is `pod.Spec.NodeName`.

This makes a transient API-server connectivity loss at startup fatal. We have observed this at scale: a roughly one-minute network blip on a node (kube API unreachable, `dial tcp 10.96.0.1:443: connect: network is unreachable`) turned into hundreds of aisnode pod terminations, with targets crash-looping under `CrashLoopBackOff` until the network recovered — extending a brief network hiccup into a considerably longer storage outage.

That query is redundant: the node name is already injected into every AIS pod via the K8s downward API.

- the ais-k8s operator sets `MY_NODE` for both targets and proxies — [`operator/internal/resources/aistore/cmn/env.go#L39`](https://github.com/NVIDIA/ais-k8s/blob/ecf9f9859a8ba1468595e6fbc9d669e41d1f317d/operator/internal/resources/aistore/cmn/env.go#L39)
- `deploy/dev/k8s` does the same for local dev, in both the [proxy](https://github.com/NVIDIA/aistore/blob/3f6cf585352c78b041cc90ceda5e517b754f0d4e/deploy/dev/k8s/base/proxy/statefulset.yaml#L98) and [target](https://github.com/NVIDIA/aistore/blob/3f6cf585352c78b041cc90ceda5e517b754f0d4e/deploy/dev/k8s/base/target/statefulset.yaml#L108) statefulsets

So there is no valid in-cluster deployment of AIS without it.

### Changes

- Resolve the node name from `MY_NODE` and drop the startup Pod query entirely — `aisnode` no longer depends on API-server reachability to start.
- Exit with a clean error when `MY_NODE` is not set.
- Extract `_initNode()` from `Init()` (behavior-preserving) to make node-name resolution unit-testable, and add tests covering the three paths: env-provided node name, pod name taken from `HOSTNAME`, and the non-K8s deployment path.

### Testing

With Go 1.26:

- `go build ./...` and `go vet ./cmn/... ./ais/... ./ext/...` — clean
- `gofmt -l cmn/k8s/` — clean
- `golangci-lint run ./cmn/k8s/...` (v2.12.2) — 0 issues
- `go test ./cmn/k8s/...` — passes; the new tests need no K8s cluster
