### PR TITLE
fix: use a valid Go download URL in the dev Docker images

### DIFF
--- a/deploy/dev/docker/Dockerfile
+++ b/deploy/dev/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py &&\
   pip install awscli s3cmd
 
 # Setting ENV variables
-ENV GOLANG_VERSION="1.26"
+ENV GOLANG_VERSION="1.26.0"
 
 # Reassign arguments to environment variables so run.sh can use them
 ENV GOPATH /go

--- a/deploy/test-in-docker/Dockerfile
+++ b/deploy/test-in-docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get clean && apt-get update &&\
 
 RUN pip3 install awscli s3cmd
 
-ENV GOLANG_VERSION="1.26"
+ENV GOLANG_VERSION="1.26.0"
 
 ENV GOPATH /go
 ENV GOBIN $GOPATH/bin


### PR DESCRIPTION
The dev and `test-in-docker` images set `GOLANG_VERSION="1.26"`, which builds `https://go.dev/dl/go1.26.linux-amd64.tar.gz` — a 404 (Go tarballs require the patch version). `curl` then saves the error page and `tar` fails, breaking the image build.

Fix: use `"1.26.0"`, which is a real tarball and matches the `go 1.26` directive in `go.mod`.

```
go1.26.linux-amd64.tar.gz   -> 404
go1.26.0.linux-amd64.tar.gz -> 200
```

Introduced in the "transition to Go 1.26" change; `deploy/ci/build.sh` is unaffected since it resolves the patch version dynamically.