### PR TITLE
fix(deploy): resolve latest Go patch when building dev/test-in-docker images

### DIFF
--- a/deploy/dev/docker/Dockerfile
+++ b/deploy/dev/docker/Dockerfile
@@ -33,11 +33,13 @@ ENV GOPATH /go
 ENV GOBIN $GOPATH/bin
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-# Installing go
+# Installing go (resolve the latest patch of ${GOLANG_VERSION} at build time)
 RUN mkdir -p "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN curl -LO https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz &&\
-  tar -C /usr/local -xvzf go${GOLANG_VERSION}.linux-amd64.tar.gz > /dev/null 2>&1 &&\
-  rm -rf go${GOLANG_VERSION}.linux-amd64.tar.gz
+RUN GO_VER=$(curl -sfL "https://go.dev/dl/?mode=json&include=all" | grep -oE "go${GOLANG_VERSION}\.[0-9]+" | sort -V | tail -1) &&\
+  test -n "${GO_VER}" &&\
+  curl -LO "https://go.dev/dl/${GO_VER}.linux-amd64.tar.gz" &&\
+  tar -C /usr/local -xvzf "${GO_VER}.linux-amd64.tar.gz" > /dev/null 2>&1 &&\
+  rm -rf "${GO_VER}.linux-amd64.tar.gz"
 
 ENV AIS_CONF_DIR /tmp/.conf
 ENV AIS_CONF_FILE ${AIS_CONF_DIR}/ais.json

--- a/deploy/test-in-docker/Dockerfile
+++ b/deploy/test-in-docker/Dockerfile
@@ -27,11 +27,13 @@ ENV GOPATH /go
 ENV GOBIN $GOPATH/bin
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-# Installing go
+# Installing go (resolve the latest patch of ${GOLANG_VERSION} at build time)
 RUN mkdir -p "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN curl -LO https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz &&\
-  tar -C /usr/local -xvzf go${GOLANG_VERSION}.linux-amd64.tar.gz > /dev/null 2>&1 &&\
-  rm -rf go${GOLANG_VERSION}.linux-amd64.tar.gz
+RUN GO_VER=$(curl -sfL "https://go.dev/dl/?mode=json&include=all" | grep -oE "go${GOLANG_VERSION}\.[0-9]+" | sort -V | tail -1) &&\
+  test -n "${GO_VER}" &&\
+  curl -LO "https://go.dev/dl/${GO_VER}.linux-amd64.tar.gz" &&\
+  tar -C /usr/local -xvzf "${GO_VER}.linux-amd64.tar.gz" > /dev/null 2>&1 &&\
+  rm -rf "${GO_VER}.linux-amd64.tar.gz"
 
 RUN go install github.com/rakyll/gotest@latest
 


### PR DESCRIPTION
### Problem

`deploy/dev/docker/Dockerfile` and `deploy/test-in-docker/Dockerfile` download Go with:

curl -LO https://go.dev/dl/go$\{GOLANG_VERSION\}.linux-amd64.tar.gz

where `GOLANG_VERSION="1.26"`. `go.dev/dl` has no `go1.26` tarball — only patch-versioned releases (`go1.26.0`, `go1.26.8`, …) — so the URL 404s and the build fails at the `tar` step. Introduced when the pin moved to Go 1.26; these two Dockerfiles aren't built by CI, so nothing caught it.

### Fix

Resolve the latest patch of the pinned minor at build time from the `go.dev/dl` JSON feed:

RUN GO_VER=$(curl -sfL "https://go.dev/dl/?mode=json&include=all" | grep -oE "go${GOLANG_VERSION}.[0-9]+" | sort -V | tail -1) &&
  test -n "${GO_VER}" &&
  curl -LO "https://go.dev/dl/${GO_VER}.linux-amd64.tar.gz" &&
  ...

Notes:
- **Scripted, always latest patch** — per the feedback on #361, this resolves today's latest `1.26.x` rather than hardcoding a patch.
- **Resolved inside `RUN`** (rather than a build-arg script like `deploy/ci/build.sh`) because these images are built by docker-compose / `make`, with no external wrapper to inject the version.
- **`include=all`** — the default `?mode=json` lists only the two newest minors, so a pinned `1.26` would resolve empty once Go ships 1.27; `include=all` covers every minor.
- **`test -n` guard** — fail fast on an empty resolution instead of a misleading `tar` error downstream.

### Testing

Ran the full resolve → guard → download → extract → `go version` pipeline natively via `sh -c` (Docker's default RUN shell): resolves `go1.26.8` and runs. Confirmed the old URL 404s and the resolved URL is 200, and that `include=all` resolves correctly for both `1.25` and `1.26`.

Follow-up to #361.
